### PR TITLE
Feat/#11 WebSocketConfig 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,9 @@ dependencies {
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// websocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/likelion/realtalk/global/config/WebSocketConfig.java
+++ b/src/main/java/com/likelion/realtalk/global/config/WebSocketConfig.java
@@ -1,0 +1,30 @@
+package com.likelion.realtalk.global.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry registry) {
+    /** 서버가 보내는 메시지를 클라이언트가 구독할 때 사용하는 경로 **/
+    registry.enableSimpleBroker("/topic"); // 구독용 경로 서버 -> 클라이언트
+
+    /**클라이언트가 서버에 메시지를 보낼 때 사용하는 경로 접두어   ->   @MessageMapping **/
+    registry.setApplicationDestinationPrefixes("/pub"); //  클라이언트 ->  서버
+  }
+
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    // 토론방 연결 endpoint
+    registry.addEndpoint("/ws-debate")
+        .setAllowedOriginPatterns("*") // TODO. 추후 변경
+        .withSockJS();
+  }
+}


### PR DESCRIPTION
## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- feature/#11

📄  **작업한 내용**
- 구독 경로 설정
- 클라이언트가 서버에게 메세지 보낼 때 접두어 설정
- endpoint 설정
- WebSocket 의존성 추가

## 🚨 참고 사항
브로커를 "/debate", "/speaker", "/ai", "/audience" 네 가지로 등록할 경우 유지보스에 어려움이 있어 "/topic"으로 통일하였습니다.
구독 경로는 "/topic/debate", "/topic/speaker" 등과 같이 설정 바랍니다.
## 💻 관련 이슈
- Resolved: #11 
