### PR TITLE
Feat/#45 시작버튼 클릭 시 토론방 status 변경 및 시작 시간 갱신

### DIFF
--- a/src/main/java/com/likelion/realtalk/domain/debate/api/DebateController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/DebateController.java
@@ -1,5 +1,6 @@
 package com.likelion.realtalk.domain.debate.api;
 
+import com.likelion.realtalk.domain.debate.dto.DebatestartResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -28,8 +29,9 @@ import com.likelion.realtalk.domain.debate.service.ParticipantService;
 import com.likelion.realtalk.domain.debate.service.RoomIdMappingService;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/debate-rooms")
 public class DebateController {
@@ -120,5 +122,13 @@ public class DebateController {
         AiSummaryResponse response = debateRoomService.findAiSummaryById(pk);
         // AiSummaryResponse response = debateRoomService.findAiSummaryById(roomId);
         return ResponseEntity.ok(response);
+    }
+
+    //status, at 변경해야하므로 POST
+    @PostMapping("/{roomUUID}/start")
+    public ResponseEntity<DebatestartResponse> startRoom(@PathVariable UUID roomUUID) {
+        Long pk = mapping.toPk(roomUUID);                  // 외부 UUID → 내부 PK
+        DebatestartResponse updated = debateRoomService.startRoom(pk,roomUUID);
+        return ResponseEntity.ok(updated);
     }
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/dto/DebatestartResponse.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/dto/DebatestartResponse.java
@@ -1,0 +1,21 @@
+package com.likelion.realtalk.domain.debate.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 시작버튼을 눌렀을 때 응답을 받기 위한 DTO 입니다.
+ *
+ * @author : 오승훈
+ * @fileName : DebatestartResponse
+ * @since : 2025-08-13
+ */
+@Data
+@Builder
+public class DebatestartResponse {
+
+  private String status;
+  private LocalDateTime startedAt; //시작시간 갱신을 위한 변수 추가
+
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/repository/DebateRoomRepository.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/repository/DebateRoomRepository.java
@@ -1,12 +1,27 @@
 package com.likelion.realtalk.domain.debate.repository;
 
+import com.likelion.realtalk.domain.debate.entity.DebateRoomStatus;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.likelion.realtalk.domain.debate.entity.DebateRoom;
 
 @Repository
 public interface DebateRoomRepository extends JpaRepository<DebateRoom, Long> {
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query("""
+        update DebateRoom r
+           set r.status = :started, r.startedAt = :now
+         where r.roomId = :id and r.status = :waiting
+    """)
+  int startIfWaiting(@Param("id") Long id,
+      @Param("now") LocalDateTime now,
+      @Param("started") DebateRoomStatus started,
+      @Param("waiting") DebateRoomStatus waiting);
 }

--- a/src/main/java/com/likelion/realtalk/global/exception/ErrorCode.java
+++ b/src/main/java/com/likelion/realtalk/global/exception/ErrorCode.java
@@ -57,9 +57,13 @@ public enum ErrorCode {
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "METHOD_NOT_ALLOWED", "허용되지 않은 HTTP 메서드입니다."),
 
+    // 409 Conflict
+    ROOM_ALREADY_STARTED(HttpStatus.CONFLICT, "ROOM_ALREADY_STARTED", "이미 시작되었거나 종료된 방입니다."),
+
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다."),
     UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "UNKNOWN_ERROR", "예기치 못한 오류가 발생했습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- feature/#45

📄  **작업한 내용**
- POST /api/debate-rooms/{roomUUID}/start 추가
- roomUUID → PK 변환 후 waiting → started, startedAt=now() 갱신
- 예외: 409 ROOM_ALREADY_STARTED
- 응답: DebatestartResponse Dto로 { status, startedAt } 최소 필드 반환

## 💻 관련 이슈
- Resolved: #45

