### PR TITLE
FEAT#41: STOMP 인증/참가 플로우 보완 — SPEAKER 로그인 강제, AUDIENCE 게스트 허용, Redis/NPE/중복구독 Fix (#41)

### DIFF
--- a/src/main/java/com/likelion/realtalk/domain/auth/api/AuthController.java
+++ b/src/main/java/com/likelion/realtalk/domain/auth/api/AuthController.java
@@ -1,24 +1,41 @@
 package com.likelion.realtalk.domain.auth.api;
 
-import com.likelion.realtalk.domain.auth.service.AuthService;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.bind.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.likelion.realtalk.domain.auth.service.AuthService;
+import com.likelion.realtalk.global.security.core.CustomUserDetails;
+import com.likelion.realtalk.global.security.jwt.JwtProvider;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
   private final AuthService authService;
+  private final JwtProvider jwtProvider; // ★ 추가
 
   @PostMapping("/refresh")
   public ResponseEntity<?> refresh(HttpServletRequest request, HttpServletResponse response) {
     authService.reissueTokens(request, response);
     return ResponseEntity.ok().build();
+  }
+
+  // ★ 추가: access token JSON으로 발급
+  @PostMapping("/token")
+  public ResponseEntity<?> issueToken(@AuthenticationPrincipal CustomUserDetails user) {
+    if (user == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    String access = jwtProvider.createToken(user, 30 * 60 * 1000L); // 30분
+    return ResponseEntity.ok(Map.of("accessToken", access));
   }
 
 }

--- a/src/main/java/com/likelion/realtalk/domain/auth/api/AuthController.java
+++ b/src/main/java/com/likelion/realtalk/domain/auth/api/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.security.web.bind.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.likelion.realtalk.domain.auth.service.AuthService;
 import com.likelion.realtalk.global.security.core.CustomUserDetails;
@@ -31,11 +32,11 @@ public class AuthController {
   }
 
   // ★ 추가: access token JSON으로 발급
-  @PostMapping("/token")
-  public ResponseEntity<?> issueToken(@AuthenticationPrincipal CustomUserDetails user) {
-    if (user == null) return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
-    String access = jwtProvider.createToken(user, 30 * 60 * 1000L); // 30분
-    return ResponseEntity.ok(Map.of("accessToken", access));
-  }
+    @PostMapping("/token")
+    public Map<String, Object> issueToken(@AuthenticationPrincipal CustomUserDetails user) {
+        if (user == null) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
+        String access = jwtProvider.createToken(user, 30 * 60 * 1000L); // 30분
+        return Map.of("accessToken", access);
+    }
 
 }

--- a/src/main/java/com/likelion/realtalk/domain/auth/api/AuthController.java
+++ b/src/main/java/com/likelion/realtalk/domain/auth/api/AuthController.java
@@ -7,7 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.web.bind.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/com/likelion/realtalk/domain/auth/api/AuthController.java
+++ b/src/main/java/com/likelion/realtalk/domain/auth/api/AuthController.java
@@ -19,14 +19,15 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
   private final AuthService authService;
   private final JwtProvider jwtProvider; // ★ 추가
 
   @PostMapping("/refresh")
-  public ResponseEntity<?> refresh(HttpServletRequest request, HttpServletResponse response) {
+  public ResponseEntity<?> refresh(HttpServletRequest request, HttpServletResponse response)
+      throws Exception {
     authService.reissueTokens(request, response);
     return ResponseEntity.ok().build();
   }

--- a/src/main/java/com/likelion/realtalk/domain/auth/api/AuthController.java
+++ b/src/main/java/com/likelion/realtalk/domain/auth/api/AuthController.java
@@ -1,22 +1,23 @@
 package com.likelion.realtalk.domain.auth.api;
 
-import java.util.Map;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.web.bind.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
-
 import com.likelion.realtalk.domain.auth.service.AuthService;
+import com.likelion.realtalk.domain.user.dto.UserInfoDto;
 import com.likelion.realtalk.global.security.core.CustomUserDetails;
-import com.likelion.realtalk.global.security.jwt.JwtProvider;
-
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.bind.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import com.likelion.realtalk.global.security.jwt.JwtProvider;
+
 
 @RestController
 @RequestMapping("/api/auth")
@@ -30,6 +31,19 @@ public class AuthController {
       throws Exception {
     authService.reissueTokens(request, response);
     return ResponseEntity.ok().build();
+  }
+
+  // 로그인 한 사용자 정보 조회
+  @GetMapping("/me")
+  public ResponseEntity<UserInfoDto> getMyProfile(
+      @AuthenticationPrincipal CustomUserDetails userDetail) {
+    UserInfoDto userInfo = UserInfoDto.withProvider(
+        userDetail.getUserId(),
+        userDetail.getUsername(),
+        userDetail.getUser().getRole(),
+        userDetail.getUser().getAuth().getProvider()
+    );
+    return ResponseEntity.ok(userInfo);
   }
 
   // ★ 추가: access token JSON으로 발급

--- a/src/main/java/com/likelion/realtalk/domain/debate/api/DebateController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/DebateController.java
@@ -168,6 +168,7 @@ public class DebateController {
             rej.put("type","JOIN_REJECTED");
             rej.put("reason","capacity_or_status");
             rej.put("role", req.getRole());
+            rej.put("nonce", req.getNonce()); // ★ 추가 (프론트 매칭용)
             messagingTemplate.convertAndSend("/sub/debate-room/" + roomUuid, rej);
             return;
         }
@@ -178,6 +179,7 @@ public class DebateController {
         acc.put("userName", displayName);
         acc.put("role", req.getRole());
         acc.put("side", req.getSide());
+        acc.put("nonce", req.getNonce()); // ★ 추가
         if (userIdOrNull != null) acc.put("userId", userIdOrNull);
 
         messagingTemplate.convertAndSend("/sub/debate-room/" + roomUuid, acc);

--- a/src/main/java/com/likelion/realtalk/domain/debate/api/DebateController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/DebateController.java
@@ -1,7 +1,8 @@
 package com.likelion.realtalk.domain.debate.api;
 
-import java.security.Principal;
+import com.likelion.realtalk.domain.debate.dto.DebatestartResponse;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
@@ -22,20 +23,20 @@ import com.likelion.realtalk.domain.debate.dto.CreateRoomRequest;
 import com.likelion.realtalk.domain.debate.dto.DebateRoomResponse;
 import com.likelion.realtalk.domain.debate.dto.JoinRequest;
 import com.likelion.realtalk.domain.debate.dto.LeaveRequest;
-import com.likelion.realtalk.domain.debate.dto.RoomUserInfo;
 import com.likelion.realtalk.domain.debate.entity.DebateRoom;
 import com.likelion.realtalk.domain.debate.service.DebateRoomService;
 import com.likelion.realtalk.domain.debate.service.ParticipantService;
-import com.likelion.realtalk.domain.debate.service.RedisRoomTracker;
 import com.likelion.realtalk.domain.debate.service.RoomIdMappingService;
-// import com.likelion.realtalk.global.security.core.CustomUserDetails;
-// import com.likelion.realtalk.global.security.jwt.JwtProvider;
+import com.likelion.realtalk.domain.debate.service.RedisRoomTracker;
+import com.likelion.realtalk.domain.debate.dto.RoomUserInfo;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
 import lombok.extern.slf4j.Slf4j;
+import java.security.Principal;
 
 @Slf4j
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/debate-rooms")
 public class DebateController {
@@ -238,5 +239,13 @@ public class DebateController {
         AiSummaryResponse response = debateRoomService.findAiSummaryById(pk);
         // AiSummaryResponse response = debateRoomService.findAiSummaryById(roomId);
         return ResponseEntity.ok(response);
+    }
+
+    //status, at 변경해야하므로 POST
+    @PostMapping("/{roomUUID}/start")
+    public ResponseEntity<DebatestartResponse> startRoom(@PathVariable UUID roomUUID) {
+        Long pk = mapping.toPk(roomUUID);                  // 외부 UUID → 내부 PK
+        DebatestartResponse updated = debateRoomService.startRoom(pk,roomUUID);
+        return ResponseEntity.ok(updated);
     }
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/api/DebateController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/DebateController.java
@@ -1,15 +1,13 @@
 package com.likelion.realtalk.domain.debate.api;
 
+import java.security.Principal;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
-import org.springframework.security.web.bind.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -17,7 +15,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.server.ResponseStatusException;
 
 import com.likelion.realtalk.domain.debate.dto.AiSummaryResponse;
 import com.likelion.realtalk.domain.debate.dto.ChatMessage;
@@ -25,15 +22,19 @@ import com.likelion.realtalk.domain.debate.dto.CreateRoomRequest;
 import com.likelion.realtalk.domain.debate.dto.DebateRoomResponse;
 import com.likelion.realtalk.domain.debate.dto.JoinRequest;
 import com.likelion.realtalk.domain.debate.dto.LeaveRequest;
+import com.likelion.realtalk.domain.debate.dto.RoomUserInfo;
 import com.likelion.realtalk.domain.debate.entity.DebateRoom;
 import com.likelion.realtalk.domain.debate.service.DebateRoomService;
 import com.likelion.realtalk.domain.debate.service.ParticipantService;
+import com.likelion.realtalk.domain.debate.service.RedisRoomTracker;
 import com.likelion.realtalk.domain.debate.service.RoomIdMappingService;
-import com.likelion.realtalk.global.security.core.CustomUserDetails;
-import com.likelion.realtalk.global.security.jwt.JwtProvider;
+// import com.likelion.realtalk.global.security.core.CustomUserDetails;
+// import com.likelion.realtalk.global.security.jwt.JwtProvider;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/api/debate-rooms")
@@ -43,71 +44,143 @@ public class DebateController {
     private final DebateRoomService debateRoomService;
     private final ParticipantService participantService;
     private final RoomIdMappingService mapping;
-    private final JwtProvider jwtProvider;
-
-    @PostMapping("/api/auth/token")
-    public Map<String, Object> issueToken(@AuthenticationPrincipal CustomUserDetails user) {
-        if (user == null) throw new ResponseStatusException(HttpStatus.UNAUTHORIZED);
-        String access = jwtProvider.createToken(user, 30 * 60 * 1000L); // 30분
-        return Map.of("accessToken", access);
-    }
+    private final RedisRoomTracker redisRoomTracker;
 
     @MessageMapping("/chat/message")
-    public void message(ChatMessage message) {
-        messagingTemplate.convertAndSend("/sub/debate-room/" + message.getRoomId(), message);
+    public void message(ChatMessage incoming, SimpMessageHeaderAccessor headers) {
+        String sessionId = headers.getSessionId();
+
+        // 1) UUID -> PK 매핑 (UUID만 넘어오는 구조라면)
+        UUID roomUuid = UUID.fromString(incoming.getRoomId());
+        Long roomPk = mapping.toPk(roomUuid);
+
+        // 2) 세션 기준으로 방 내 사용자 정보 조회 (예: Redis에 저장해둔 RoomUserInfo)
+        RoomUserInfo ui = redisRoomTracker.findBySession(roomPk, sessionId);
+
+        // 3) 서버가 브로드캐스트용 payload 구성 (클라 sender는 무시)
+        ChatMessage out = new ChatMessage();
+        out.setRoomId(incoming.getRoomId());
+        out.setMessage(incoming.getMessage());
+        out.setType("CHAT");
+        out.setTimestamp(System.currentTimeMillis());
+
+        if (ui != null) {
+            out.setUserName(ui.getUserName());
+            out.setUserId(ui.getUserId());
+            out.setRole(ui.getRole());
+            out.setSide(ui.getSide());
+        } else {
+            // 세션으로 못 찾았을 때의 안전장치: 인증 주체나 세션 꼬리표로 표기
+            Principal p = headers.getUser();
+            String fallback =
+                (p != null) ? p.getName()
+                            : ("guest:" + (sessionId != null && sessionId.length() > 6
+                                        ? sessionId.substring(sessionId.length()-6)
+                                        : "unknown"));
+            out.setUserName(fallback);
+            out.setUserId(null);
+            out.setRole("AUDIENCE");
+            out.setSide("A");
+        }
+
+        messagingTemplate.convertAndSend("/sub/debate-room/" + incoming.getRoomId(), out);
     }
 
     @MessageMapping("/debate/join")
     public void join(JoinRequest req, SimpMessageHeaderAccessor header) {
-        String sessionId = header.getSessionId();
         UUID roomUuid = req.getRoomId();
-        Long pk = mapping.toPk(roomUuid);
+        String sessionId = header.getSessionId();
 
-        // CONNECT 인터셉터에서 Authentication.setUser(...) 세팅되어 있어야 함
-        var auth = (org.springframework.security.core.Authentication) header.getUser();
-        var principal = (com.likelion.realtalk.domain.debate.auth.RoomPrincipal) auth.getPrincipal();
+        // 1) Principal 꺼내기 (RoomPrincipal 기준으로 인증 판정)
+        Object userObj = header.getUser();
+        org.springframework.security.core.Authentication auth =
+            (userObj instanceof org.springframework.security.core.Authentication)
+                ? (org.springframework.security.core.Authentication) userObj : null;
 
+        com.likelion.realtalk.domain.debate.auth.RoomPrincipal rp =
+            (auth != null && auth.getPrincipal() instanceof com.likelion.realtalk.domain.debate.auth.RoomPrincipal)
+                ? (com.likelion.realtalk.domain.debate.auth.RoomPrincipal) auth.getPrincipal()
+                : null;
+
+        boolean isAuth = rp != null && rp.isAuthenticated() && rp.getUserId() != null;
+        System.out.println("[JOIN][DBG] principalClass=" + (rp==null? "null" : rp.getClass().getSimpleName())
+        + ", rp.isAuthenticated=" + (rp!=null && rp.isAuthenticated())
+        + ", rp.userId=" + (rp!=null ? rp.getUserId() : null)
+        + ", computed.isAuth=" + isAuth);
+        Long uid       = (rp != null) ? rp.getUserId() : null;
+        String name    = (rp != null) ? rp.getDisplayName() : null;
+
+        // 2) SPEAKER는 로그인(인증) 필수 / AUDIENCE는 선택
         boolean wantsSpeaker = "SPEAKER".equalsIgnoreCase(req.getRole());
-        if (wantsSpeaker && !principal.isAuthenticated()) {
-            messagingTemplate.convertAndSend(
-                "/sub/debate-room/" + roomUuid,
-                Map.of("type","JOIN_REJECTED","reason","auth_required","role", req.getRole())
-            );
+        if (wantsSpeaker && !isAuth) {
+            System.out.println("wantsSpeaker: " + wantsSpeaker + " isAuth: "+ isAuth);
+            String reason = (rp == null || rp instanceof com.likelion.realtalk.domain.debate.auth.GuestPrincipal || uid == null)
+                            ? "auth_required" : "auth_broken";
+            var rej = new java.util.HashMap<String,Object>();
+            rej.put("type","JOIN_REJECTED");
+            rej.put("reason", reason);
+            rej.put("role", req.getRole());
+            messagingTemplate.convertAndSend("/sub/debate-room/" + roomUuid, rej);
             return;
         }
 
-        String subjectId = principal.isAuthenticated()
-                ? ("user:" + principal.getUserId())
-                : ("guest:" + sessionId);
+        // 3) UUID -> PK 매핑
+        Long pk;
+        try {
+            pk = mapping.toPk(roomUuid);
+            log.info("[입장] 방 UUID={} → PK={}", roomUuid, pk);
+        } catch (Exception e) {
+            var rej = new java.util.HashMap<String,Object>();
+            rej.put("type","JOIN_REJECTED");
+            rej.put("reason","invalid_room");
+            messagingTemplate.convertAndSend("/sub/debate-room/" + roomUuid, rej);
+            return;
+        }
 
-        boolean ok = participantService.tryAddUserToRoomByPk(
-            pk,
-            subjectId,
-            sessionId,
-            req.getRole(),
-            req.getSide(),
-            principal.getDisplayName(),
-            principal.isAuthenticated(),
-            principal.getUserId() // 로그인 사용자면 Long, 게스트면 null
-        );
+        // 4) 표시명/주체 구성 (널/길이 안전)
+        String safeGuest   = "게스트 " + (sessionId != null ? sessionId.substring(0, Math.min(6, sessionId.length())) : "UNKNOWN");
+        String displayName = isAuth
+            ? ((name != null && !name.isBlank()) ? name : ("User-" + uid))
+            : safeGuest;
+        String subjectId   = isAuth ? ("userId:" + uid) : ("guest:" + sessionId);
+        Long   userIdOrNull = isAuth ? uid : null;
+
+        log.info("[입장] 참가 시도: PK={}, 주체={}, 역할={}, 사이드={}, 인증여부={}, 표시명={}",
+                pk, subjectId, req.getRole(), req.getSide(), isAuth, displayName);
+
+        // 5) 참가 처리 (Redis 반영 포함)
+        boolean ok;
+        try {
+            ok = participantService.tryAddUserToRoomByPk(
+                    pk, subjectId, sessionId, req.getRole(), req.getSide(),
+                    displayName, isAuth, userIdOrNull);
+        } catch (Exception svcEx) {
+            log.error("[입장] 참가 처리 중 예외 발생: {}", svcEx.toString(), svcEx);
+            var rej = new java.util.HashMap<String,Object>();
+            rej.put("type","JOIN_REJECTED");
+            rej.put("reason","server_error");
+            messagingTemplate.convertAndSend("/sub/debate-room/" + roomUuid, rej);
+            return;
+        }
 
         if (!ok) {
-            messagingTemplate.convertAndSend(
-                "/sub/debate-room/" + roomUuid,
-                Map.of("type","JOIN_REJECTED","reason","capacity_or_status","role", req.getRole())
-            );
+            var rej = new java.util.HashMap<String,Object>();
+            rej.put("type","JOIN_REJECTED");
+            rej.put("reason","capacity_or_status");
+            rej.put("role", req.getRole());
+            messagingTemplate.convertAndSend("/sub/debate-room/" + roomUuid, rej);
             return;
         }
 
-        // (선택) 성공 알림
-        messagingTemplate.convertAndSend(
-            "/sub/debate-room/" + roomUuid,
-            Map.of("type","JOIN_ACCEPTED",
-                  "userId", principal.isAuthenticated() ? principal.getUserId() : null,
-                  "userName", principal.getDisplayName(),
-                  "role", req.getRole(),
-                  "side", req.getSide())
-        );
+        // 6) 성공 브로드캐스트 (HashMap: null 허용)
+        var acc = new java.util.HashMap<String,Object>();
+        acc.put("type","JOIN_ACCEPTED");
+        acc.put("userName", displayName);
+        acc.put("role", req.getRole());
+        acc.put("side", req.getSide());
+        if (userIdOrNull != null) acc.put("userId", userIdOrNull);
+
+        messagingTemplate.convertAndSend("/sub/debate-room/" + roomUuid, acc);
     }
 
     @MessageMapping("/debate/leave") 

--- a/src/main/java/com/likelion/realtalk/domain/debate/auth/AuthUserPrincipal.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/auth/AuthUserPrincipal.java
@@ -1,0 +1,23 @@
+package com.likelion.realtalk.domain.debate.auth;
+
+import java.util.Collection;
+import org.springframework.security.core.GrantedAuthority;
+
+public class AuthUserPrincipal implements RoomPrincipal {
+    private final Long userId;
+    private final String userName;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public AuthUserPrincipal(Long userId, String userName,
+                             Collection<? extends GrantedAuthority> authorities) {
+        this.userId = userId;
+        this.userName = userName;
+        this.authorities = authorities;
+    }
+
+    @Override public boolean isAuthenticated() { return true; }
+    @Override public Long getUserId() { return userId; }
+    @Override public String getName() { return userName; }
+    @Override public String getDisplayName() { return userName; }
+    public Collection<? extends GrantedAuthority> getAuthorities() { return authorities; }
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/auth/GuestPrincipal.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/auth/GuestPrincipal.java
@@ -1,0 +1,16 @@
+package com.likelion.realtalk.domain.debate.auth;
+
+public class GuestPrincipal implements RoomPrincipal {
+    private final String guestId;    // "guest-AB12CD"
+    private final String guestName;  // "게스트 AB12CD"
+
+    public GuestPrincipal(String guestId, String guestName) {
+        this.guestId = guestId;
+        this.guestName = guestName;
+    }
+
+    @Override public boolean isAuthenticated() { return false; }
+    @Override public Long getUserId() { return null; }
+    @Override public String getName() { return guestId; }
+    @Override public String getDisplayName() { return guestName; }
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/auth/RoomPrincipal.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/auth/RoomPrincipal.java
@@ -1,0 +1,9 @@
+package com.likelion.realtalk.domain.debate.auth;
+
+import java.security.Principal;
+
+public interface RoomPrincipal extends Principal {
+    boolean isAuthenticated();     // 로그인 사용자면 true, 게스트면 false
+    Long getUserId();              // 게스트면 null
+    String getDisplayName();       // userName 또는 guestName
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/dto/ChatMessage.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/dto/ChatMessage.java
@@ -6,7 +6,14 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ChatMessage {
-    private String roomId;
-    private String sender;
-    private String message;
+    private String roomId;     // UUID 문자열
+    private String message;    // 내용
+
+    // 서버가 채워서 내려줄 메타들
+    private String userName;   // 표시명
+    private Long   userId;     // 로그인 사용자 PK (게스트면 null)
+    private String role;       // SPEAKER / AUDIENCE
+    private String side;       // A / B
+    private String type;       // "CHAT" | "START" | "FINISH" 등
+    private long   timestamp;  // epoch millis
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/dto/JoinRequest.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/dto/JoinRequest.java
@@ -12,4 +12,5 @@ public class JoinRequest {
     // private String userId;
     private String role;
     private String side;
+    private String nonce;
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/dto/JoinRequest.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/dto/JoinRequest.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Setter
 public class JoinRequest {
     private UUID roomId;
-    private String userId;
+    // private String userId;
     private String role;
     private String side;
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/dto/RoomUserInfo.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/dto/RoomUserInfo.java
@@ -12,7 +12,12 @@ import lombok.Setter;
 @AllArgsConstructor
 @Builder
 public class RoomUserInfo {
-    private String userId;
-    private String role; // SPEAKER, AUDIENCE
-    private String side;  // A / B
+    private String sessionId;      // Redis 해시 field (세션 기준)
+    private String subjectId;      // "user:123" 또는 "guest:{sessionId}"
+    private Long   userId;         // 로그인 사용자 PK, 게스트는 null
+    private String userName;       // 화면에 보여줄 이름 (회원명/게스트명)
+    private String role;           // SPEAKER / AUDIENCE
+    private String side;           // A / B
+    private boolean authenticated; // 로그인 여부
+    // (옵션) private Long joinedAt; // epoch seconds 저장했다면 추가
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/service/DebateStartEventListener.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/service/DebateStartEventListener.java
@@ -22,7 +22,8 @@ public class DebateStartEventListener {
         Map<String, Object> message = new HashMap<>();
         message.put("type", "START");
         message.put("message", "토론을 시작합니다");
-        message.put("participants", redisRoomTracker.getWaitingUsers(room.getRoomId()));
+        message.put("participants",
+            new java.util.ArrayList<>(redisRoomTracker.getRoomUserInfosByPk(room.getRoomId()).values()));
         messagingTemplate.convertAndSend("/sub/debate-room/" + room.getRoomId(), message);
     }
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/service/ParticipantService.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/service/ParticipantService.java
@@ -1,13 +1,6 @@
 package com.likelion.realtalk.domain.debate.service;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.boot.context.event.ApplicationReadyEvent;
@@ -26,59 +19,47 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ParticipantService {
 
-    // Map<roomId, Map<sessionId, userId>>
-    // private final Map<Long, Map<String, String>> roomParticipants = new ConcurrentHashMap<>();
+    // Map<roomPk, Map<sessionId, RoomUserInfo>>
     private final Map<Long, Map<String, RoomUserInfo>> roomParticipants = new ConcurrentHashMap<>();
 
     private final SimpMessageSendingOperations messagingTemplate;
-    
     private final RedisRoomTracker redisRoomTracker;
     private final DebateRoomRepository debateRoomRepository;
     private final DebateEventPublisher debateEventPublisher;
-
     private final RoomIdMappingService mapping;
 
-    //사용자 추가
-    // public void addUserToRoom(Long roomId, String userId, String sessionId) {
-    public void addUserToRoomByPk(Long pk, String userId, String sessionId, String role, String side) {
-        RoomUserInfo userInfo = RoomUserInfo.builder()
-                .userId(userId)
-                .role(role)
-                .side(side)
-                .build();
-
-        // 사용자 등록
-        roomParticipants
-                .computeIfAbsent(pk, k -> new ConcurrentHashMap<>())
-                .put(sessionId, userInfo);
-
-        // redis에도 추가 
-        redisRoomTracker.userJoinedByPk(pk, userId, role, side);
-
-        //상태 확인 및 시작 조건 체크
-        handleRoomStartCheck(pk);
-
-        // 브로드캐스트
-        broadcastParticipants(pk);
-        broadcastAllRooms();
-    }
-
-    /** 정원 검증 + 등록 (원자적) */
-    public boolean tryAddUserToRoomByPk(Long pk, String userId, String sessionId, String role, String side) {
+    /** 정원 검증 + 등록 (원자적) — 세션 기준 + Principal 정보 반영 */
+    public boolean tryAddUserToRoomByPk(Long pk,
+                                        String subjectId,     // "user:{userId}" | "guest:{sessionId}"
+                                        String sessionId,
+                                        String role,
+                                        String side,
+                                        String displayName,   // userName/게스트명
+                                        boolean authenticated,
+                                        Long userId           // 로그인 사용자 PK or null
+    ) {
         var room = debateRoomRepository.findById(pk).orElse(null);
         if (room == null) return false;
-
         if (room.getStatus() == DebateRoomStatus.ended) return false;
 
         int max = "SPEAKER".equals(role) ? room.getMaxSpeaker().intValue()
                                          : room.getMaxAudience().intValue();
 
-        boolean ok = redisRoomTracker.tryEnter(pk, role, userId, max, side);
+        boolean ok = redisRoomTracker.tryEnter(
+            pk, role, sessionId, max, subjectId, userId, displayName, side, authenticated
+        );
         if (!ok) return false; // 정원 초과
 
-        // 메모리(세션 매핑) 갱신
+        // 메모리 갱신 — 세션 기준
         RoomUserInfo userInfo = RoomUserInfo.builder()
-                .userId(userId).role(role).side(side).build();
+                .sessionId(sessionId)
+                .subjectId(subjectId)
+                .userId(userId)
+                .userName(displayName)
+                .authenticated(authenticated)
+                .role(role)
+                .side(side)
+                .build();
 
         roomParticipants.computeIfAbsent(pk, k -> new ConcurrentHashMap<>())
                         .put(sessionId, userInfo);
@@ -92,36 +73,14 @@ public class ParticipantService {
         return true;
     }
 
-    // (이행기용) UUID를 직접 받는 진입점이 필요하면 이 오버로드 사용 가능
-    public void addUserToRoom(UUID roomUuid, String userId, String sessionId, String role, String side) {
-        Long pk = mapping.toPk(roomUuid);
-        addUserToRoomByPk(pk, userId, sessionId, role, side);
-    }
-
-    // 토론 시작 조건
-    private void handleRoomStartCheck(Long pk) {
-        DebateRoom room = debateRoomRepository.findById(pk).orElse(null);
-
-        if (room != null && room.getStatus() == DebateRoomStatus.waiting) {
-            long speakerCount = redisRoomTracker.getCurrentSpeakers(pk); // ✅ 수정: 스피커만
-            if (speakerCount >= room.getMaxSpeaker()) {
-                room.setStatus(DebateRoomStatus.started);
-                debateRoomRepository.save(room);
-                debateEventPublisher.publishDebateStart(room);
-            }
-        }
-    }
-
-     //세션 ID로 사용자 제거 (브라우저 종료 등)
+    // 세션 ID로 사용자 제거 (브라우저 종료 등)
     public void removeUserBySession(String sessionId) {
         for (Long pk : roomParticipants.keySet()) {
             Map<String, RoomUserInfo> sessionMap = roomParticipants.get(pk);
             if (sessionMap != null && sessionMap.containsKey(sessionId)) {
-                RoomUserInfo removedUser = sessionMap.remove(sessionId);
-
-                if( removedUser != null) {
-                    redisRoomTracker.leave(pk,removedUser.getRole() ,removedUser.getUserId());
-                }
+                sessionMap.remove(sessionId);
+                // Redis 정리 (역할 몰라도 세션 기준)
+                redisRoomTracker.removeSession(pk, sessionId);
 
                 broadcastParticipants(pk);
                 broadcastAllRooms();
@@ -130,14 +89,14 @@ public class ParticipantService {
         }
     }
 
-    // 특정 방에서 userId로 강제 제거 (직접 나가기 버튼 눌렀을 경우 등)
-    public void removeUserFromRoom(Long pk, String userId) {
+    // 특정 방에서 주체(subjectId)로 강제 제거 (관리자 등)
+    public void removeUserFromRoom(Long pk, String subjectId) {
         Map<String, RoomUserInfo> sessionMap = roomParticipants.get(pk);
         if (sessionMap != null) {
             sessionMap.entrySet().removeIf(entry -> {
-                boolean match = userId.equals(entry.getValue().getUserId());
+                boolean match = subjectId.equals(entry.getValue().getSubjectId());
                 if (match) {
-                    redisRoomTracker.userLeftByPk(pk, userId);
+                    redisRoomTracker.removeSession(pk, entry.getKey()); // sessionId
                 }
                 return match;
             });
@@ -151,93 +110,75 @@ public class ParticipantService {
         return new ArrayList<>(roomParticipants.getOrDefault(pk, Collections.emptyMap()).values());
     }
 
-    // 현재 방의 유저 목록 반환
-    // public List<String> getUsersInRoom(Long roomId) {
-    //     return new ArrayList<>(roomParticipants.getOrDefault(roomId, Collections.emptyMap()).values());
-    // }
-
-    // public List<String> getUsersInRoom(Long roomId) {
-    //     return roomParticipants.getOrDefault(roomId, Collections.emptyMap())
-    //             .values()
-    //             .stream()
-    //             .map(RoomUserInfo::getUserId)
-    //             .toList();
-    // }
-
     public Collection<RoomUserInfo> getDetailedUsersInRoom(Long pk) {
         return roomParticipants.getOrDefault(pk, Collections.emptyMap()).values();
     }
 
-    // 브로드캐스트 (해당 방에 실시간 참여자 목록 전달)
+    // 브로드캐스트 (해당 방 참여자 목록 전달)
     public void broadcastParticipants(Long pk) {
         Collection<RoomUserInfo> sessions = roomParticipants.getOrDefault(pk, Collections.emptyMap()).values();
+        // 동일 사용자 다중 세션을 합치고 싶으면 subjectId 기준으로 dedup
         Map<String, RoomUserInfo> dedup = new HashMap<>();
-        for (RoomUserInfo u : sessions) dedup.put(u.getUserId(), u);
+        for (RoomUserInfo u : sessions) {
+            String key = (u.getSubjectId() != null) ? u.getSubjectId() : u.getSessionId();
+            dedup.put(key, u);
+        }
         UUID uuid = safeToUuid(pk);
         messagingTemplate.convertAndSend("/sub/debate-room/" + uuid + "/participants", dedup.values());
     }
 
     public void broadcastAllRooms() {
         Map<UUID, Collection<RoomUserInfo>> allRooms = new HashMap<>();
-
         for (Long pk : roomParticipants.keySet()) {
             UUID uuid = safeToUuid(pk);
-            allRooms.put(uuid, roomParticipants.get(pk).values()); // <-- 핵심: RoomUserInfo 객체 그대로 넣기
+            allRooms.put(uuid, roomParticipants.get(pk).values());
         }
-
         messagingTemplate.convertAndSend("/sub/debate-room/all/participants", allRooms);
+    }
+
+    private void handleRoomStartCheck(Long pk) {
+        DebateRoom room = debateRoomRepository.findById(pk).orElse(null);
+        if (room != null && room.getStatus() == DebateRoomStatus.waiting) {
+            long speakerCount = redisRoomTracker.getCurrentSpeakers(pk);
+            if (speakerCount >= room.getMaxSpeaker()) {
+                room.setStatus(DebateRoomStatus.started);
+                debateRoomRepository.save(room);
+                debateEventPublisher.publishDebateStart(room);
+            }
+        }
     }
 
     private UUID safeToUuid(Long pk) {
         try {
             return mapping.toUuid(pk);
         } catch (Exception e) {
-            // 매핑이 없을 수도 있으니 방어
             return UUID.nameUUIDFromBytes(("missing-" + pk).getBytes());
         }
     }
 
+    // 서버 시작 시 Redis -> 메모리 초기화
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        initRoomParticipantsFromRedis();
+        broadcastAllRooms();
+    }
+
     public void initRoomParticipantsFromRedis() {
-        // Redis에 존재하는 모든 roomId를 가져온다 (예: debateRoom:{roomId}:waitingUsers)
-        // Set<String> keys = redisRoomTracker.getAllRoomKeys(); // 예: debateRoom:1:waitingUsers 등
-
         Set<Long> pks = redisRoomTracker.getAllRoomPks();
-
         for (Long pk : pks) {
             Map<String, RoomUserInfo> userMap = redisRoomTracker.getRoomUserInfosByPk(pk);
             if (userMap == null) userMap = Collections.emptyMap();
 
-            // UUID roomId = extractRoomIdFromKey(key); // 예: "debateRoom:1:waitingUsers" → 1
-
-            // null entry 방어
+            // 게스트도 포함해야 하므로 userId null 허용, role/side 존재만 체크
             Map<String, RoomUserInfo> cleaned = new ConcurrentHashMap<>();
             for (Map.Entry<String, RoomUserInfo> e : userMap.entrySet()) {
-                if (e.getKey() != null && e.getValue() != null
-                        && e.getValue().getUserId() != null
-                        && e.getValue().getRole()   != null
-                        && e.getValue().getSide()   != null) {
-                    cleaned.put(e.getKey(), e.getValue());
+                RoomUserInfo v = e.getValue();
+                if (e.getKey() != null && v != null
+                        && v.getRole() != null && v.getSide() != null) {
+                    cleaned.put(e.getKey(), v);
                 }
             }
             roomParticipants.put(pk, cleaned);
         }
     }
-
-    private UUID extractRoomIdFromKey(String key) {
-        // key: "debateRoom:550e8400-e29b-41d4-a716-446655440000:waitingUsers"
-        try {
-            String[] parts = key.split(":");
-            return UUID.fromString(parts[1]); // ← 여기서 변환
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    @EventListener(ApplicationReadyEvent.class)
-    public void onApplicationReady() {
-        initRoomParticipantsFromRedis(); // 💡 Redis에서 초기화
-        System.out.println("✅ 서버 시작됨 - 전체 참여자 목록 초기 브로드캐스트 실행");
-        broadcastAllRooms();
-    }
-
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/service/RedisRoomTracker.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/service/RedisRoomTracker.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -21,30 +20,35 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RedisRoomTracker {
 
-    private static final String WAITING_ROOM_KEY_PREFIX = "debateRoom:";
-    private static final String WAITING_USERS_KEY_SUFFIX = ":waitingUsers";
+    private static final String ROOM_KEY_PREFIX = "debateRoom:";
+    private static final String PARTICIPANTS_SUFFIX = ":waitingUsers";
     private static final String SPEAKERS = ":speakers";
     private static final String AUDIENCES = ":audiences";
 
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private String waitingKey(Long pk){
-        return WAITING_ROOM_KEY_PREFIX + pk + WAITING_USERS_KEY_SUFFIX;
+    private String participantsKey(Long pk) {
+        return ROOM_KEY_PREFIX + pk + PARTICIPANTS_SUFFIX;
+    }
+    private String speakersKey(Long pk)    { return ROOM_KEY_PREFIX + pk + SPEAKERS; }
+    private String audiencesKey(Long pk)   { return ROOM_KEY_PREFIX + pk + AUDIENCES; }
+
+    private Long safeLong(Object v) {
+        if (v == null) return null;
+        try { return Long.valueOf(String.valueOf(v)); }
+        catch (NumberFormatException e) { return null; }
     }
 
-    private String speakersKey(Long pk){
-        return WAITING_ROOM_KEY_PREFIX + pk + SPEAKERS;
+    private boolean safeBool(Object v) {
+        if (v instanceof Boolean b) return b;
+        return v != null && Boolean.parseBoolean(String.valueOf(v));
     }
 
-    private String audiencesKey(Long pk){
-        return WAITING_ROOM_KEY_PREFIX + pk + AUDIENCES;
-    }
-
-    /** 원자적 입장 (역할별 정원 체크 후 SADD + 상세 Hash 저장) */
+    /** 원자적 입장 (역할별 정원 체크 후 SADD + 상세 Hash 저장) - 세션 기준 */
     private final DefaultRedisScript<Long> tryEnterLua = new DefaultRedisScript<>(
-        // KEYS[1] = roleSetKey, KEYS[2] = waitingHashKey
-        // ARGV[1] = max, ARGV[2] = userId, ARGV[3] = json({role,side})
+        // KEYS[1] = roleSetKey, KEYS[2] = participantsHashKey
+        // ARGV[1] = max, ARGV[2] = sessionId, ARGV[3] = json
         "local cnt = redis.call('SCARD', KEYS[1]) " +
         "if cnt >= tonumber(ARGV[1]) then return 0 end " +
         "redis.call('SADD', KEYS[1], ARGV[2]) " +
@@ -52,163 +56,106 @@ public class RedisRoomTracker {
         "return 1"
     , Long.class);
 
-    public boolean tryEnter(Long pk, String role, String userId, int max, String side) {
-        String roleSet = "SPEAKER".equals(role) ? speakersKey(pk) : audiencesKey(pk);
-        String wKey = waitingKey(pk);
+    /** 입장: 세션 단위 */
+    public boolean tryEnter(Long pk,
+                            String role,
+                            String sessionId,
+                            int max,
+                            String subjectId,     // "user:{userId}" or "guest:{sessionId}"
+                            Long userId,          // 게스트면 null
+                            String userName,      // 표시명
+                            String side,
+                            boolean authenticated) {
 
-        Map<String, String> userInfo = Map.of("userId", userId, "role", role, "side", side);
+        String roleSet = "SPEAKER".equals(role) ? speakersKey(pk) : audiencesKey(pk);
+        String pKey = participantsKey(pk);
+
+        Map<String, Object> userInfo = Map.of(
+            "subjectId", subjectId,
+            "userId", userId,
+            "userName", userName,
+            "role", role,
+            "side", side,
+            "authenticated", authenticated,
+            "joinedAt", System.currentTimeMillis() / 1000
+        );
+
         String json;
         try { json = objectMapper.writeValueAsString(userInfo); }
         catch (JsonProcessingException e) { throw new RuntimeException(e); }
 
         Long ok = redisTemplate.execute(
             tryEnterLua,
-            List.of(roleSet, wKey),
-            String.valueOf(max), userId, json
+            List.of(roleSet, pKey),
+            String.valueOf(max), sessionId, json
         );
         return ok != null && ok == 1L;
     }
 
-    /** 퇴장(역할 세트/해시에서 제거) */
-    public void leave(Long pk, String role, String userId) {
+    /** 퇴장(역할 세트/해시에서 제거) - 역할 알고 있으면 */
+    public void leave(Long pk, String role, String sessionId) {
         String roleSet = "SPEAKER".equals(role) ? speakersKey(pk) : audiencesKey(pk);
-        redisTemplate.opsForSet().remove(roleSet, userId);
-        redisTemplate.opsForHash().delete(waitingKey(pk), userId);
+        redisTemplate.opsForSet().remove(roleSet, sessionId);
+        redisTemplate.opsForHash().delete(participantsKey(pk), sessionId);
     }
 
-    public long getCurrentSpeakers(Long pk)   { return size(speakersKey(pk)); }
-    public long getCurrentAudiences(Long pk)  { return size(audiencesKey(pk)); }
+    /** 퇴장(역할 모를 때 세션만으로 정리) */
+    public void removeSession(Long pk, String sessionId) {
+        redisTemplate.opsForSet().remove(speakersKey(pk), sessionId);
+        redisTemplate.opsForSet().remove(audiencesKey(pk), sessionId);
+        redisTemplate.opsForHash().delete(participantsKey(pk), sessionId);
+    }
+
+    public long getCurrentSpeakers(Long pk)  { return size(speakersKey(pk)); }
+    public long getCurrentAudiences(Long pk) { return size(audiencesKey(pk)); }
     private long size(String key) {
         Long n = redisTemplate.opsForSet().size(key);
         return n == null ? 0L : n;
     }
 
-    public void userJoinedByPk(Long pk, String userId, String role, String side) {
-        String key = WAITING_ROOM_KEY_PREFIX + pk + WAITING_USERS_KEY_SUFFIX;
-
-        Map<String, String> userInfo = Map.of(
-            "userId", userId,     // ✅ 명시적으로 JSON 내부에 포함
-            "role", role,
-            "side", side
-        );
-
-        try {
-            String json = objectMapper.writeValueAsString(userInfo);
-            redisTemplate.opsForHash().put(key, userId, json); // Redis key는 그대로 userId
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("Redis 저장용 JSON 직렬화 실패", e);
-        }
-    }
-
-    public void userLeftByPk(Long pk, String userId) {
-        String key = waitingKey(pk);
-        redisTemplate.opsForHash().delete(key, userId);
-    }
-
-    public Set<String> getWaitingUsers(Long pk) {
-        String key = waitingKey(pk);
-        return redisTemplate.opsForHash().keys(key).stream()
-                .map(Object::toString)
-                .collect(Collectors.toSet());
-    }
-
-    public long getWaitingUserCountByPk(Long pk) {
-        String key = waitingKey(pk);
-        Long count = redisTemplate.opsForHash().size(key);
-        return count != null ? count : 0;
-    }
-
-    // public long getCurrentSpeakers(Long pk) {
-    //     return countByRole(pk, "SPEAKER");
-    // }
-    //
-    // public long getCurrentAudiences(Long pk) {
-    //     return countByRole(pk, "AUDIENCE");
-    // }
-
-    private long countByRole(Long pk, String role) {
-        String key = waitingKey(pk);
+    /** 참가자 상세 조회 (세션 기준) */
+    public Map<String, RoomUserInfo> getRoomUserInfosByPk(Long pk) {
+        String key = participantsKey(pk);
         Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
-        return entries.values().stream().filter(value -> {
+
+        Map<String, RoomUserInfo> out = new HashMap<>();
+        for (Map.Entry<Object, Object> e : entries.entrySet()) {
+            String sessionId = String.valueOf(e.getKey());
+            String json = String.valueOf(e.getValue());
             try {
                 @SuppressWarnings("unchecked")
-                Map<String, String> parsed = objectMapper.readValue(value.toString(), Map.class);
-                return role.equals(parsed.get("role"));
-            } catch (JsonProcessingException e) {
-                return false;
-            }
-        }).count();
-    }
+                Map<String, Object> data = objectMapper.readValue(json, Map.class);
 
-    public Map<String, Map<String, String>> getWaitingUserInfos(UUID roomId) {
-        String key = WAITING_ROOM_KEY_PREFIX + roomId + WAITING_USERS_KEY_SUFFIX;
-        Map<Object, Object> rawEntries = redisTemplate.opsForHash().entries(key);
-        Map<String, Map<String, String>> result = new HashMap<>();
+                RoomUserInfo info = RoomUserInfo.builder()
+                    .sessionId(sessionId)
+                    .subjectId((String) data.get("subjectId"))
+                    .userId(safeLong(data.get("userId")))             // ← 숫자 아니면 null
+                    .userName((String) data.get("userName"))
+                    .role(String.valueOf(data.get("role")))
+                    .side(String.valueOf(data.get("side")))
+                    .authenticated(safeBool(data.get("authenticated")))
+                    .build();
 
-        for (Map.Entry<Object, Object> entry : rawEntries.entrySet()) {
-            String userId = entry.getKey().toString();
-            String json = entry.getValue().toString();
-            try {
-                @SuppressWarnings("unchecked")
-                Map<String, String> parsed = objectMapper.readValue(json, Map.class);
-                result.put(userId, parsed);
-            } catch (JsonProcessingException e) {
-                // skip malformed
+                out.put(sessionId, info);
+            } catch (JsonProcessingException ignore) {
+                // malformed entry skip
             }
         }
-
-        return result;
+        return out;
     }
 
     public Set<Long> getAllRoomPks() {
-        Set<String> keys = redisTemplate.keys(WAITING_ROOM_KEY_PREFIX + "*"+ WAITING_USERS_KEY_SUFFIX);
+        Set<String> keys = redisTemplate.keys(ROOM_KEY_PREFIX + "*" + PARTICIPANTS_SUFFIX);
         if (keys == null || keys.isEmpty()) return Set.of();
-
-        return keys.stream()
-                .map(this::extractPkFromKey)
-                .filter(pk -> pk != null)
-                .collect(Collectors.toSet());
-    }
-
-    public Map<String, RoomUserInfo> getRoomUserInfosByPk(Long pk) {
-        String key = waitingKey(pk);
-        Map<Object, Object> entries = redisTemplate.opsForHash().entries(key);
-
-        Map<String, RoomUserInfo> userInfos = new HashMap<>();
-
-        for (Map.Entry<Object, Object> entry : entries.entrySet()) {
-            String userId = entry.getKey().toString();
-            String json = entry.getValue().toString();
-            try {
-                @SuppressWarnings("unchecked")
-                Map<String, String> data = objectMapper.readValue(json, Map.class);
-
-                RoomUserInfo userInfo = RoomUserInfo.builder()
-                    .userId(userId) // ✅ 여기서 직접 넣어줌
-                    .role(data.get("role"))
-                    .side(data.get("side"))
-                    .build();
-
-                userInfos.put(userId, userInfo);
-
-            } catch (JsonProcessingException e) {
-                // 예외 처리
-            }
-        }
-
-        return userInfos;
+        return keys.stream().map(this::extractPkFromKey).filter(pk -> pk != null).collect(Collectors.toSet());
     }
 
     private Long extractPkFromKey(String key) {
-        // key 예: "room:123:waitingUsers"
+        // "debateRoom:123:waitingUsers"
         try {
-            int a = key.indexOf(':');              // after "room"
-            int b = key.lastIndexOf(':');          // before "waitingUsers"
-            String num = key.substring(a + 1, b);  // "123"
-            return Long.parseLong(num);
-        } catch (Exception e) {
-            return null;
-        }
+            int a = key.indexOf(':');
+            int b = key.lastIndexOf(':');
+            return Long.parseLong(key.substring(a + 1, b));
+        } catch (Exception e) { return null; }
     }
-
 }

--- a/src/main/java/com/likelion/realtalk/global/config/WebSocketConfig.java
+++ b/src/main/java/com/likelion/realtalk/global/config/WebSocketConfig.java
@@ -1,24 +1,44 @@
 package com.likelion.realtalk.global.config;
 
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import com.likelion.realtalk.domain.debate.auth.AuthUserPrincipal;
+import com.likelion.realtalk.domain.debate.auth.GuestPrincipal;
 import com.likelion.realtalk.domain.webrtc.handler.SignalingHandler;
+import com.likelion.realtalk.global.security.jwt.JwtProvider;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer, WebSocketConfigurer {
 
   private final SignalingHandler signalingHandler;
 
-  public WebSocketConfig(SignalingHandler signalingHandler) {
-    this.signalingHandler = signalingHandler;
-  }
+
+  private final JwtProvider jwt;  
+
+  // public WebSocketConfig(SignalingHandler signalingHandler) {
+  //   this.signalingHandler = signalingHandler;
+  // }
 
   @Override
   public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -50,4 +70,31 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer, WebSoc
     registry.addHandler(signalingHandler, "/ws-signaling")
         .setAllowedOriginPatterns("*"); // TODO: 운영 시 도메인 제한
   }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor acc = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+                if (acc == null) return message;
+                if (StompCommand.CONNECT.equals(acc.getCommand())) {
+                    String authHeader = first(acc.getNativeHeader("Authorization"));
+                    if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                        String token = authHeader.substring(7);
+                        if (!jwt.validate(token)) throw new IllegalArgumentException("Invalid JWT");
+                        var principal = new AuthUserPrincipal(jwt.getUserId(token), jwt.getUsername(token), jwt.getAuthorities(token));
+                        var auth = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+                        acc.setUser(auth);
+                    } else {
+                        String suf = UUID.randomUUID().toString().substring(0, 6).toUpperCase();
+                        var principal = new GuestPrincipal("guest-" + suf, "게스트 " + suf);
+                        var auth = new UsernamePasswordAuthenticationToken(principal, null, List.of());
+                        acc.setUser(auth);
+                    }
+                }
+                return message;
+            }
+            private String first(List<String> list) { return (list != null && !list.isEmpty()) ? list.get(0) : null; }
+        });
+    }
 }

--- a/src/main/java/com/likelion/realtalk/global/config/WebSocketConfig.java
+++ b/src/main/java/com/likelion/realtalk/global/config/WebSocketConfig.java
@@ -75,26 +75,44 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer, WebSoc
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(new ChannelInterceptor() {
             @Override public Message<?> preSend(Message<?> message, MessageChannel channel) {
-                StompHeaderAccessor acc = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
-                if (acc == null) return message;
-                if (StompCommand.CONNECT.equals(acc.getCommand())) {
-                    String authHeader = first(acc.getNativeHeader("Authorization"));
-                    if (authHeader != null && authHeader.startsWith("Bearer ")) {
-                        String token = authHeader.substring(7);
-                        if (!jwt.validate(token)) throw new IllegalArgumentException("Invalid JWT");
-                        var principal = new AuthUserPrincipal(jwt.getUserId(token), jwt.getUsername(token), jwt.getAuthorities(token));
+            var acc = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+            if (acc == null) return message;
+
+            if (StompCommand.CONNECT.equals(acc.getCommand())) {
+                String h = first(acc.getNativeHeader("Authorization"));
+                if (h == null) h = first(acc.getNativeHeader("authorization"));
+                System.out.println("[STOMP][DBG] hasHeader=" + (h!=null) + " endpoint=" + acc.getDestination());
+
+                    boolean authenticated = false;
+                if (h != null && h.startsWith("Bearer ")) {
+                    String token = h.substring(7);
+                    boolean valid = jwt.validate(token);
+                    System.out.println("[STOMP][DBG] jwt.validate=" + valid);
+                    if (valid) {
+                    Long uid = jwt.getUserId(token);
+                    String uname = jwt.getUsername(token);
+                    System.out.println("[STOMP][DBG] parsed uid=" + uid + " uname=" + uname);
+                    if (uid != null && uname != null && !uname.isBlank()) {
+                        var principal = new AuthUserPrincipal(uid, uname, jwt.getAuthorities(token));
                         var auth = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
                         acc.setUser(auth);
-                    } else {
-                        String suf = UUID.randomUUID().toString().substring(0, 6).toUpperCase();
-                        var principal = new GuestPrincipal("guest-" + suf, "게스트 " + suf);
-                        var auth = new UsernamePasswordAuthenticationToken(principal, null, List.of());
-                        acc.setUser(auth);
+                        authenticated = true;
+                        System.out.println("[STOMP][DBG] set AuthUserPrincipal OK");
+                    }
                     }
                 }
-                return message;
+                if (!authenticated) {
+                    String suf = java.util.UUID.randomUUID().toString().substring(0, 6).toUpperCase();
+                    var principal = new GuestPrincipal("guest-" + suf, "게스트 " + suf);
+                    var auth = new UsernamePasswordAuthenticationToken(principal, null); // 미인증
+                    acc.setUser(auth);
+                    System.out.println("[STOMP][DBG] set GuestPrincipal (unauthenticated)");
+                }
             }
-            private String first(List<String> list) { return (list != null && !list.isEmpty()) ? list.get(0) : null; }
+            return message;
+            }
+            private String first(java.util.List<String> list) { return (list != null && !list.isEmpty()) ? list.get(0) : null; }
         });
     }
+
 }

--- a/src/main/java/com/likelion/realtalk/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/likelion/realtalk/global/security/jwt/JwtProvider.java
@@ -1,10 +1,17 @@
 package com.likelion.realtalk.global.security.jwt;
 
 import com.likelion.realtalk.global.security.core.CustomUserDetails;
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.JwtException;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -22,6 +29,10 @@ public class JwtProvider {
         .subject(principal.getUsername())
         .claim("userId", principal.getUserId())
         .claim("username", principal.getUsername())
+        // 권한 정보를 토큰에 포함(없어도 동작은 가능하지만, 있으면 WebSocket 권한 세팅이 편합니다)
+        .claim("roles", principal.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.toList()))
         .issuedAt(now)
         .expiration(expiry)
         .signWith(secretKey, Jwts.SIG.HS256)
@@ -41,6 +52,29 @@ public class JwtProvider {
     }
   }
 
+  // alias: validate (WebSocket 쪽에서 이 이름으로 호출해도 되게)
+  public boolean validate(String token) {
+    return validateToken(token);
+  }
+
+  // 토큰에서 권한 목록 추출 (roles 클레임이 없으면 빈 리스트 반환)
+  public Collection<? extends GrantedAuthority> getAuthorities(String token) {
+    Claims claims = Jwts.parser()
+        .verifyWith(secretKey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload();
+
+    Object roles = claims.get("roles");
+    if (roles instanceof List<?> list) {
+      return list.stream()
+          .map(String::valueOf)
+          .map(SimpleGrantedAuthority::new)
+          .collect(Collectors.toList());
+    }
+    return List.of();
+  }
+
   // 토큰에서 사용자 ID 추출
   public Long getUserId(String token) {
     return Jwts.parser()
@@ -51,7 +85,7 @@ public class JwtProvider {
         .get("userId", Long.class);
   }
 
-  // 토큰에서 username 추출 (예: 인증 과정에서 필요시)
+  // 토큰에서 username 추출
   public String getUsername(String token) {
     return Jwts.parser()
         .verifyWith(secretKey)
@@ -61,7 +95,7 @@ public class JwtProvider {
         .get("username", String.class);
   }
 
-  // 토큰 만료 여부 체크 (선택)
+  // 만료 여부 체크
   public boolean isTokenExpired(String token) {
     Date expiration = Jwts.parser()
         .verifyWith(secretKey)
@@ -71,5 +105,4 @@ public class JwtProvider {
         .getExpiration();
     return expiration.before(new Date());
   }
-
 }

--- a/src/main/java/com/likelion/realtalk/global/security/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/likelion/realtalk/global/security/jwt/JwtTokenFilter.java
@@ -61,7 +61,8 @@ public class JwtTokenFilter extends OncePerRequestFilter {
         String path = request.getServletPath();
         // 1. 인증/인가, 로그인 등 공개 API
         return path.startsWith("/oauth2/")
-            || path.startsWith("/auth/")
+            || path.startsWith("/auth/refresh")
+            || path.startsWith("/auth/logout")
             || path.startsWith("/login/")
 
             // 2. 공통 리소스(정적 파일, 헬스체크)

--- a/src/main/resources/static/debateroom.html
+++ b/src/main/resources/static/debateroom.html
@@ -132,7 +132,7 @@
     if (!require) return null;
 
     // ★ SPEAKER 등 강제 필요 시에만 새 토큰 발급
-    const res = await fetch('/auth/token', { method:'POST', credentials:'include' });
+    const res = await fetch('/api/auth/token', { method:'POST', credentials:'include' });
     if (!res.ok) return null;
     const { accessToken } = await res.json();
     localStorage.setItem('access_token', accessToken);

--- a/src/main/resources/static/debateroom.html
+++ b/src/main/resources/static/debateroom.html
@@ -78,6 +78,11 @@
     let userId = null;
     let userNameMessage = null;
 
+    // [추가] 내 정보 & 락 & (선택) 요청 식별용 nonce
+    const currentUser = { id: null, name: null, role: null, side: null };
+    let selfInfoLocked = false;   // 내 "You are:" UI는 한 번만 세팅
+    let myJoinNonce = null;       // 서버가 echo 해주면 정확 매칭용(없어도 동작)
+
     function createRoom() {
         const room = {
         title: document.getElementById('title').value,
@@ -156,6 +161,13 @@
         console.log('[웹소켓] joinRoom 호출:', { 방ID: roomId, 역할: role, 사이드: side });
         currentRoomId = roomId;
 
+        // [추가] 재접속 전에 내 식별 정보 초기화 (isFirstAccept가 true가 되도록)
+        currentUser.id = null;
+        currentUser.name = null;
+        currentUser.role = null;
+        currentUser.side = null;
+        selfInfoLocked = false; 
+
         // 토큰 확보 + 만료 정보 로그
         const token = await ensureAccessToken({ require: role === 'SPEAKER' });
 
@@ -193,35 +205,68 @@
         function onConnect(frame) {
             console.log('[웹소켓] STOMP 연결 성공:', frame);
 
+            // [추가] 새 연결 때마다 내 정보 다시 세팅 가능하도록 락 해제
+            selfInfoLocked = false;
+
             const topicRoom = `/sub/debate-room/${roomId}`;
             const topicParticipants = `/sub/debate-room/${roomId}/participants`;
 
             console.log('[웹소켓] 구독 시작1:', topicRoom);
             stompClient.subscribe(topicRoom, function (message) {
-            let payload;
-            try {
-                payload = JSON.parse(message.body);
-                console.log('payplad:', payload);
-            } catch (e) {
-                console.error('[웹소켓][수신] JSON 파싱 실패:', e, message.body);
-                return;
-            }
-            console.log('[웹소켓][수신] 방 브로드캐스트:', payload);
+                let payload;
+                try {
+                    payload = JSON.parse(message.body);
+                    console.log('payplad:', payload);
+                } catch (e) {
+                    console.error('[웹소켓][수신] JSON 파싱 실패:', e, message.body);
+                    return;
+                }
+                console.log('[웹소켓][수신] 방 브로드캐스트:', payload);
 
-            showMessage(payload);
+                showMessage(payload);
 
-            if (payload.type === 'JOIN_ACCEPTED') {
-                const { userId: acceptedUserId, userName, role: joinedRole, side: joinedSide } = payload;
-                document.getElementById('room-info').textContent = `RoomId: ${roomId}`;
-                document.getElementById('user-info').textContent =
-                `You are: ${userName}${acceptedUserId ? ` (#${acceptedUserId})` : ''} (${joinedRole}, side ${joinedSide})`;
-                document.getElementById('chat-box').style.display = 'block';
-                console.log('[웹소켓] 참가 승인 수신: UI 갱신 완료');
-            }
+                if (payload.type === 'JOIN_ACCEPTED') {
+                    // [보강] 내 JOIN인지 판별
+                    const isMineByNonce = payload.nonce && typeof myJoinNonce === 'string' && payload.nonce === myJoinNonce;
+                    const isFirstAccept = !selfInfoLocked && !currentUser?.name; // 서버가 nonce 미지원일 때 대안
+                    const isMyAccept    = isMineByNonce || isFirstAccept;
 
-            if (payload.type === 'JOIN_REJECTED') {
-                console.warn('[웹소켓] 참가 거절 수신:', payload);
-            }
+                    const { userId: acceptedUserId, userName, role: joinedRole, side: joinedSide } = payload;
+
+                    console.warn("isMineByNonce:",isMineByNonce);
+                    console.warn("isFirstAccept:",isFirstAccept);
+                    console.warn("isMyAccept:",isMyAccept);
+                    console.warn("selfInfoLocked:",selfInfoLocked);
+
+                    if (isMyAccept && !selfInfoLocked) {
+                        // [보강] 내 정보 고정(한 번만)
+                        currentUser.id   = acceptedUserId ?? null;
+                        currentUser.name = userName ?? null;
+                        currentUser.role = joinedRole ?? null;
+                        currentUser.side = joinedSide ?? null;
+
+                        document.getElementById('room-info').textContent = `RoomId: ${roomId}`;
+                        document.getElementById('user-info').textContent =
+                        `You are: ${currentUser.name}${acceptedUserId ? ` (#${acceptedUserId})` : ''} (${joinedRole}, side ${joinedSide})`;
+                        document.getElementById('chat-box').style.display = 'block';
+
+                        selfInfoLocked = true;
+
+                        // 기존 로그 보존 + 상세 로그 추가
+                        console.log('[웹소켓] 참가 승인 수신: UI 갱신 완료');
+                        console.log('[웹소켓] 참가 승인 수신(내 것):', { acceptedUserId, userName, joinedRole, joinedSide, nonce: payload.nonce });
+                    } else {
+                        // 다른 사람 JOIN_ACCEPTED는 내 UI 갱신 안 함
+                        console.log('[웹소켓] 참가 승인 수신(다른 사람): UI 갱신 생략', { acceptedUserId, userName, joinedRole, joinedSide, nonce: payload.nonce });
+                    }
+                }
+
+                if (payload.type === 'JOIN_REJECTED') {
+                const mine = payload.nonce && payload.nonce === myJoinNonce; // ★ 내 요청만 처리
+                if (!mine) return;
+                console.warn('[웹소켓] 참가 거절(내 요청):', payload);
+                // 필요한 UI 처리...
+                }
             });
 
             console.log('[웹소켓] 구독 시작2:', topicParticipants);
@@ -238,7 +283,11 @@
             renderParticipants(participants);
             });
 
-            const joinPayload = { roomId, role, side };
+            // [추가] 내 요청 식별자(서버가 echo 해주면 정확 매칭)
+            myJoinNonce = Math.random().toString(36).slice(2, 10);
+
+
+            const joinPayload = { roomId, role, side, nonce: myJoinNonce }; // [추가] nonce 포함
             console.log('[웹소켓][송신] /pub/debate/join:', joinPayload);
             stompClient.send('/pub/debate/join', {}, JSON.stringify(joinPayload));
 
@@ -247,7 +296,7 @@
         },
         function onError(err) {
             const msg = (err && err.headers && err.headers.message) ? err.headers.message : '알 수 없는 오류';
-            console.error('[웹소켓][오류] STOMP 연결 실패:', { 메시지: msg, 원본: err });
+            console.log('[웹소켓][오류] STOMP 연결 실패:', { 메시지: msg, 원본: err });
             alert('WebSocket 연결에 실패했습니다. (' + msg + ')');
         }
         );
@@ -326,6 +375,14 @@
         document.getElementById('chat-box').style.display = 'none';
         currentRoomId = null;
         userId = null;
+
+        // [수정] 다음 입장 때 isFirstAccept가 true가 되도록 모두 초기화
+        selfInfoLocked = false;
+        myJoinNonce = null;
+        currentUser.id = null;
+        currentUser.name = null;
+        currentUser.role = null;
+        currentUser.side = null;
         });
     }
 

--- a/src/main/resources/static/debateroom.html
+++ b/src/main/resources/static/debateroom.html
@@ -78,6 +78,11 @@
     let userId = null;
     let userNameMessage = null;
 
+    // [추가-중복방지] 구독 핸들과 연결 중복 방지 락
+    let roomSub = null;
+    let participantsSub = null;
+    let connectInFlight = false;
+
     // [추가] 내 정보 & 락 & (선택) 요청 식별용 nonce
     const currentUser = { id: null, name: null, role: null, side: null };
     let selfInfoLocked = false;   // 내 "You are:" UI는 한 번만 세팅
@@ -161,6 +166,24 @@
         console.log('[웹소켓] joinRoom 호출:', { 방ID: roomId, 역할: role, 사이드: side });
         currentRoomId = roomId;
 
+        // [추가-중복방지] 동시에 여러 번 연결 시도 방지
+        if (connectInFlight) {
+        console.warn('[웹소켓] 이미 연결 진행 중입니다. 중복 연결 차단.');
+        return;
+        }
+        connectInFlight = true;
+
+        // [추가-중복방지] 이전 구독/연결 정리
+        try {
+        if (roomSub) { roomSub.unsubscribe(); roomSub = null; }
+        if (participantsSub) { participantsSub.unsubscribe(); participantsSub = null; }
+        if (stompClient && stompClient.connected) {
+            await new Promise(res => stompClient.disconnect(res));
+        }
+        } catch (e) {
+        console.warn('[웹소켓] 이전 연결 정리 중 경고:', e);
+        }
+
         // [추가] 재접속 전에 내 식별 정보 초기화 (isFirstAccept가 true가 되도록)
         currentUser.id = null;
         currentUser.name = null;
@@ -212,7 +235,8 @@
             const topicParticipants = `/sub/debate-room/${roomId}/participants`;
 
             console.log('[웹소켓] 구독 시작1:', topicRoom);
-            stompClient.subscribe(topicRoom, function (message) {
+            // [수정-중복방지] 구독 핸들을 저장해 두고, 재참여 시 언서브
+            roomSub = stompClient.subscribe(topicRoom, function (message) {
                 let payload;
                 try {
                     payload = JSON.parse(message.body);
@@ -270,7 +294,8 @@
             });
 
             console.log('[웹소켓] 구독 시작2:', topicParticipants);
-            stompClient.subscribe(topicParticipants, function (message) {
+            // [수정-중복방지] 구독 핸들을 저장해 두고, 재참여 시 언서브
+            participantsSub = stompClient.subscribe(topicParticipants, function (message) {
             let participants;
             try {
                 participants = JSON.parse(message.body);
@@ -286,18 +311,19 @@
             // [추가] 내 요청 식별자(서버가 echo 해주면 정확 매칭)
             myJoinNonce = Math.random().toString(36).slice(2, 10);
 
-
             const joinPayload = { roomId, role, side, nonce: myJoinNonce }; // [추가] nonce 포함
             console.log('[웹소켓][송신] /pub/debate/join:', joinPayload);
             stompClient.send('/pub/debate/join', {}, JSON.stringify(joinPayload));
 
-            // (선택) 루프백 테스트: 브로커 경로가 정상인지 확인하고 싶을 때
-            // stompClient.send('/pub/chat/message', {}, JSON.stringify({ roomId, message: 'ping from client' }));
+            // [추가-중복방지] 연결 플래그 해제
+            connectInFlight = false;
         },
         function onError(err) {
             const msg = (err && err.headers && err.headers.message) ? err.headers.message : '알 수 없는 오류';
             console.log('[웹소켓][오류] STOMP 연결 실패:', { 메시지: msg, 원본: err });
             alert('WebSocket 연결에 실패했습니다. (' + msg + ')');
+            // [추가-중복방지] 연결 실패 시에도 락 해제
+            connectInFlight = false;
         }
         );
     }
@@ -336,7 +362,6 @@
         const content = messageInput.value.trim();
         if (!content) return;
 
-
         stompClient.send("/pub/chat/message", {}, JSON.stringify({
             roomId: currentRoomId,
             message: content
@@ -364,7 +389,27 @@
     }
 
     function leaveRoom() {
-        if (!stompClient || !stompClient.connected) return;
+        // [추가-중복방지] 먼저 구독 해제
+        try {
+        if (roomSub) { roomSub.unsubscribe(); roomSub = null; }
+        if (participantsSub) { participantsSub.unsubscribe(); participantsSub = null; }
+        } catch (e) {
+        console.warn('[웹소켓] 언서브 중 경고:', e);
+        }
+
+        if (!stompClient || !stompClient.connected) {
+        // [수정] 다음 입장 때 isFirstAccept가 true가 되도록 모두 초기화
+        document.getElementById('chat-box').style.display = 'none';
+        currentRoomId = null;
+        userId = null;
+        selfInfoLocked = false;
+        myJoinNonce = null;
+        currentUser.id = null;
+        currentUser.name = null;
+        currentUser.role = null;
+        currentUser.side = null;
+        return;
+        }
 
         stompClient.send("/pub/debate/leave", {}, JSON.stringify({
         roomId: currentRoomId

--- a/src/main/resources/static/debateroom.html
+++ b/src/main/resources/static/debateroom.html
@@ -73,219 +73,263 @@
         <button onclick="leaveRoom()">Leave Room</button>
     </div>
     <script>
-        let stompClient = null;
-        let currentRoomId = null;
-        let userId = null;
+    let stompClient = null;
+    let currentRoomId = null;
+    let userId = null;
+    let userNameMessage = null;
 
-        function createRoom() {
-            const room = {
-                title: document.getElementById('title').value,
-                debateDescription: document.getElementById('debateDescription').value,
-                categoryId: document.getElementById('categoryId').value,
-                userId: document.getElementById('userId').value,
-                debateType: document.getElementById('debateType').value,
-                durationSeconds: document.getElementById('durationSeconds').value,
-                sideA: document.getElementById('sideA').value,
-                sideB: document.getElementById('sideB').value,
-                maxSpeaker: document.getElementById('maxSpeaker').value,
-                maxAudience: document.getElementById('maxAudience').value
-            };
+    function createRoom() {
+        const room = {
+        title: document.getElementById('title').value,
+        debateDescription: document.getElementById('debateDescription').value,
+        categoryId: document.getElementById('categoryId').value,
+        userId: document.getElementById('userId').value,
+        debateType: document.getElementById('debateType').value,
+        durationSeconds: document.getElementById('durationSeconds').value,
+        sideA: document.getElementById('sideA').value,
+        sideB: document.getElementById('sideB').value,
+        maxSpeaker: document.getElementById('maxSpeaker').value,
+        maxAudience: document.getElementById('maxAudience').value
+        };
 
-            fetch('/api/debate-rooms/', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(room)
-            })
-            .then(response => response.json())
-            .then(data => {
-                console.log('Room created:', data);
-                loadRooms();
-            })
-            .catch(err => console.error('방 생성 실패:', err));
+        fetch('/api/debate-rooms/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(room)
+        })
+        .then(response => response.json())
+        .then(data => {
+            console.log('Room created:', data);
+            loadRooms();
+        })
+        .catch(err => console.error('방 생성 실패:', err));
+    }
+
+    // ✅ 기존 함수에 옵션 추가: require=false면 새 발급 안 함
+    async function ensureAccessToken({ require = false } = {}) {
+    const isExpired = (t) => {
+        try {
+        const p = JSON.parse(atob(t.split('.')[1].replace(/-/g,'+').replace(/_/g,'/')));
+        const now = Math.floor(Date.now()/1000);
+        return !p.exp || p.exp < now + 30;
+        } catch { return true; }
+    };
+
+    let t = localStorage.getItem('access_token');
+    if (t && !isExpired(t)) return t;
+
+    // ★ AUDIENCE 등 게스트 흐름: 새 발급하지 않고 null 반환
+    if (!require) return null;
+
+    // ★ SPEAKER 등 강제 필요 시에만 새 토큰 발급
+    const res = await fetch('/auth/token', { method:'POST', credentials:'include' });
+    if (!res.ok) return null;
+    const { accessToken } = await res.json();
+    localStorage.setItem('access_token', accessToken);
+    return accessToken;
+    }
+
+    function loadRooms() {
+        fetch('/api/debate-rooms/all')
+        .then(response => response.json())
+        .then(data => {
+            const roomList = document.getElementById('room-list');
+            roomList.innerHTML = '';
+            data.forEach(room => {
+            const li = document.createElement('li');
+            li.textContent = `[${room.roomId}] ${room.title} - ${room.status}`;
+
+            const joinButton = document.createElement('button');
+            joinButton.textContent = 'Join';
+            joinButton.onclick = async () => { await joinRoom(room.roomId, 'AUDIENCE', 'A'); };
+            li.appendChild(joinButton);
+
+            roomList.appendChild(li);
+            });
+        })
+        .catch(error => {
+            console.error('방 목록 불러오기 실패:', error);
+        });
+    }
+
+    async function joinRoom(roomId, role = 'AUDIENCE', side = 'A') {
+        console.log('[웹소켓] joinRoom 호출:', { 방ID: roomId, 역할: role, 사이드: side });
+        currentRoomId = roomId;
+
+        // 토큰 확보 + 만료 정보 로그
+        const token = await ensureAccessToken({ require: role === 'SPEAKER' });
+
+        if (token) {
+        try {
+            const b64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+            const payload = JSON.parse(atob(b64));
+            const expLocal = new Date(payload.exp * 1000).toLocaleString();
+            console.log('[웹소켓] 토큰 확보:', { 길이: token.length, 만료시각_초: payload.exp, 만료시각_로컬: expLocal, 사용자: payload.sub });
+        } catch (e) {
+            console.warn('[웹소켓] 토큰 디코딩 실패:', e);
+        }
+        } else {
+        console.warn('[웹소켓] 토큰 없음: 게스트로 시도합니다(AUDIENCE 허용 시)');
         }
 
-        // function getAccessToken() {
-        //     // 로그인 시 저장해둔 액세스 토큰을 반환 (예: localStorage)
-        //     return localStorage.getItem('access_token');
-        // }
-        async function ensureAccessToken() {
-          let t = localStorage.getItem('access_token');
-          if (t) return t;
-          const res = await fetch('/auth/token', { method: 'POST', credentials: 'include' });
-          if (!res.ok) return null;
-          const { accessToken } = await res.json();
-          localStorage.setItem('access_token', accessToken);
-          return accessToken;
-        }
+        const connectHeaders = (role === 'AUDIENCE')
+            ? {} // ★ AUDIENCE는 게스트로 접속
+            : (token ? { Authorization: 'Bearer ' + token, authorization: 'Bearer ' + token } : {});
+        console.log('[웹소켓] CONNECT 헤더:', connectHeaders);
 
-        function loadRooms() {
-            fetch('/api/debate-rooms/all')
-                .then(response => response.json())
-                .then(data => {
-                    const roomList = document.getElementById('room-list');
-                    roomList.innerHTML = '';
-                    data.forEach(room => {
-                        const li = document.createElement('li');
-                        li.textContent = `[${room.roomId}] ${room.title} - ${room.status}`;
+        const socket = new SockJS('/ws-stomp');
+        socket.onopen = () => console.log('[웹소켓] SockJS 연결 열림');
+        socket.onclose = (e) => console.warn('[웹소켓] SockJS 연결 종료:', e);
+        socket.onerror = (e) => console.error('[웹소켓] SockJS 오류:', e);
 
-                        const joinButton = document.createElement('button');
-                        joinButton.textContent = 'Join';
-                        // 3) 방 리스트 Join 버튼: async + await (기본 AUDIENCE/A)
-                        joinButton.onclick = async () => { await joinRoom(room.roomId, 'AUDIENCE', 'A'); };
-                        li.appendChild(joinButton);
+        stompClient = Stomp.over(socket);
+        stompClient.debug = (msg) => console.log('[STOMP 디버그]', msg); // 필요 없으면 null로 끄기
+        stompClient.heartbeat.outgoing = 10000;
+        stompClient.heartbeat.incoming = 10000;
 
-                        roomList.appendChild(li);
-                    });
-                })
-                .catch(error => {
-                    console.error('방 목록 불러오기 실패:', error);
-                });
-        }
+        console.log('[웹소켓] STOMP connect 호출');
+        stompClient.connect(
+        connectHeaders,
+        function onConnect(frame) {
+            console.log('[웹소켓] STOMP 연결 성공:', frame);
 
-        // 기존: function joinRoom(roomId, userId, role, side) {
-        async function joinRoom(roomId, role, side) {
-            role = role || 'AUDIENCE';
-            side = side || 'A';
-            currentRoomId = roomId;
+            const topicRoom = `/sub/debate-room/${roomId}`;
+            const topicParticipants = `/sub/debate-room/${roomId}/participants`;
 
-            const token = await ensureAccessToken();
-            console.log("token:", token)
-            if (role === 'SPEAKER' && !token) {
-                alert('발언자로 참여하려면 로그인이 필요합니다.');
-                // 로그인 페이지로 이동 등
+            console.log('[웹소켓] 구독 시작1:', topicRoom);
+            stompClient.subscribe(topicRoom, function (message) {
+            let payload;
+            try {
+                payload = JSON.parse(message.body);
+                console.log('payplad:', payload);
+            } catch (e) {
+                console.error('[웹소켓][수신] JSON 파싱 실패:', e, message.body);
                 return;
             }
+            console.log('[웹소켓][수신] 방 브로드캐스트:', payload);
 
-            const socket = new SockJS('/ws-stomp');
-            stompClient = Stomp.over(socket);
+            showMessage(payload);
 
-            // ★ 토큰을 CONNECT 헤더에 실어 보냄
-            const connectHeaders = token ? { Authorization: 'Bearer ' + token } : {};
+            if (payload.type === 'JOIN_ACCEPTED') {
+                const { userId: acceptedUserId, userName, role: joinedRole, side: joinedSide } = payload;
+                document.getElementById('room-info').textContent = `RoomId: ${roomId}`;
+                document.getElementById('user-info').textContent =
+                `You are: ${userName}${acceptedUserId ? ` (#${acceptedUserId})` : ''} (${joinedRole}, side ${joinedSide})`;
+                document.getElementById('chat-box').style.display = 'block';
+                console.log('[웹소켓] 참가 승인 수신: UI 갱신 완료');
+            }
 
-            stompClient.connect(connectHeaders, function (frame) {
-                console.log('Connected: ' + frame);
-
-                // 룸 브로드캐스트 구독
-                stompClient.subscribe('/sub/debate-room/' + roomId, function (message) {
-                const payload = JSON.parse(message.body);
-                showMessage(payload);
-
-                // 입장 성공 시 서버가 내려주는 사용자 정보로 UI 갱신
-                if (payload.type === 'JOIN_ACCEPTED') {
-                    const { userId: acceptedUserId, userName, role: joinedRole, side: joinedSide } = payload;
-
-                    document.getElementById('room-info').textContent = `RoomId: ${roomId}`;
-                    document.getElementById('user-info').textContent =
-                    `You are: ${userName} (#${acceptedUserId}) (${joinedRole}, side ${joinedSide})`;
-                    document.getElementById('chat-box').style.display = 'block';
-                }
-
-                if (payload.type === 'JOIN_REJECTED') {
-                    alert('입장 실패: ' + (payload.reason || 'unknown'));
-                }
-                });
-
-                // 참가자 목록 구독
-                stompClient.subscribe(`/sub/debate-room/${roomId}/participants`, function (message) {
-                const participants = JSON.parse(message.body);
-                console.log("📥 [단일방] 참가자 목록 수신:", participants);
-                renderParticipants(participants);
-                });
-
-                // ★ 조인 전송: userId는 보내지 않음 (서버가 Principal로 식별)
-                stompClient.send("/pub/debate/join", {}, JSON.stringify({
-                roomId: roomId,
-                role: role,
-                side: side
-                }));
-            }, function (err) {
-                console.error('STOMP error:', err);
-                alert('WebSocket 연결에 실패했습니다.');
+            if (payload.type === 'JOIN_REJECTED') {
+                console.warn('[웹소켓] 참가 거절 수신:', payload);
+            }
             });
-        }
 
-        function renderParticipants(participants) {
-            const list = document.getElementById("participantList");
-            list.innerHTML = ""; // 초기화
-
-            if (!Array.isArray(participants)) {
-                console.warn("❗ 참가자 목록이 유효하지 않습니다:", participants);
+            console.log('[웹소켓] 구독 시작2:', topicParticipants);
+            stompClient.subscribe(topicParticipants, function (message) {
+            let participants;
+            try {
+                participants = JSON.parse(message.body);
+            } catch (e) {
+                console.error('[웹소켓][참가자] JSON 파싱 실패:', e, message.body);
                 return;
             }
-
-            participants.forEach(function (user) {
-                const displayName = user.userName || user.userId; // userName 우선
-                const li = document.createElement("li");
-                li.textContent = `👤 ${displayName} (${user.role}, Side ${user.side})`;
-                list.appendChild(li);
+            const count = Array.isArray(participants) ? participants.length : '알수없음';
+            console.log(`[웹소켓][참가자] 목록 수신(${count}명):`, participants);
+            renderParticipants(participants);
             });
+
+            const joinPayload = { roomId, role, side };
+            console.log('[웹소켓][송신] /pub/debate/join:', joinPayload);
+            stompClient.send('/pub/debate/join', {}, JSON.stringify(joinPayload));
+
+            // (선택) 루프백 테스트: 브로커 경로가 정상인지 확인하고 싶을 때
+            // stompClient.send('/pub/chat/message', {}, JSON.stringify({ roomId, message: 'ping from client' }));
+        },
+        function onError(err) {
+            const msg = (err && err.headers && err.headers.message) ? err.headers.message : '알 수 없는 오류';
+            console.error('[웹소켓][오류] STOMP 연결 실패:', { 메시지: msg, 원본: err });
+            alert('WebSocket 연결에 실패했습니다. (' + msg + ')');
+        }
+        );
+    }
+
+    function renderParticipants(participants) {
+        const list = document.getElementById("participantList");
+        list.innerHTML = ""; // 초기화
+
+        if (!Array.isArray(participants)) {
+        console.warn("❗ 참가자 목록이 유효하지 않습니다:", participants);
+        return;
         }
 
-        async function joinRoomFromForm() {
-            const roomId = document.getElementById('join-room-id').value;
-            const role = document.getElementById('join-role').value;
-            const side = document.getElementById('join-side').value;
+        participants.forEach(function (user) {
+        const displayName = user.userName || user.userId; // userName 우선
+        const li = document.createElement("li");
+        li.textContent = `👤 ${displayName} (${user.role}, Side ${user.side})`;
+        list.appendChild(li);
+        });
+    }
 
-            if (!roomId || !role || !side) {
-                alert("Room ID, Role, Side를 모두 선택/입력하세요.");
-                return;
-            }
-            // 기존: joinRoom(roomId, userId, role, side);
-            joinRoom(roomId, role, side);
+    async function joinRoomFromForm() {
+        const roomId = document.getElementById('join-room-id').value;
+        const role = document.getElementById('join-role').value;
+        const side = document.getElementById('join-side').value;
+
+        if (!roomId || !role || !side) {
+        alert("Room ID, Role, Side를 모두 선택/입력하세요.");
+        return;
+        }
+        joinRoom(roomId, role, side);
+    }
+
+    function sendMessage() {
+        const messageInput = document.getElementById('message');
+        const content = messageInput.value.trim();
+        if (!content) return;
+
+
+        stompClient.send("/pub/chat/message", {}, JSON.stringify({
+            roomId: currentRoomId,
+            message: content
+        }));
+        messageInput.value = '';
+    }
+
+    function showMessage(message) {
+        const messages = document.getElementById('messages');
+        const p = document.createElement('p');
+
+        if (message.type === 'START' || message.type === 'FINISH') {
+        p.style.fontWeight = 'bold';
+        p.style.color = message.type === 'START' ? 'green' : 'red';
         }
 
-        function sendMessage() {
-            const messageInput = document.getElementById('message');
-            const content = messageInput.value.trim();
-            if (!content) return;
+        console.log("message: ", message);
+        const sender = message.userName || message.sender || '👤익명';
+        const content = message.message || message.content || '';
+        const typePrefix = message.type ? `[${message.type}] ` : '';
 
-            const message = {
-                roomId: currentRoomId,
-                // sender 제거
-                message: content
-            };
+        p.textContent = `${typePrefix}${sender}: ${content}`;
+        messages.appendChild(p);
+        messages.scrollTop = messages.scrollHeight;
+    }
 
-            stompClient.send("/pub/chat/message", {}, JSON.stringify(message));
-            messageInput.value = '';
-        }
+    function leaveRoom() {
+        if (!stompClient || !stompClient.connected) return;
 
-        function showMessage(message) {
-            const messages = document.getElementById('messages');
-            const p = document.createElement('p');
+        stompClient.send("/pub/debate/leave", {}, JSON.stringify({
+        roomId: currentRoomId
+        }));
 
-            // 예시: type START, FINISH 등일 경우 구분 표시
-            if (message.type === 'START' || message.type === 'FINISH') {
-                p.style.fontWeight = 'bold';
-                p.style.color = message.type === 'START' ? 'green' : 'red';
-            }
+        stompClient.disconnect(() => {
+        console.log("Disconnected from room " + currentRoomId);
+        document.getElementById('chat-box').style.display = 'none';
+        currentRoomId = null;
+        userId = null;
+        });
+    }
 
-            console.log("message: ",message);
-            // ✅ 보낸 사람과 메시지 함께 출력
-            const sender = message.sender || '👤익명';
-            const content = message.message || message.content || '';
-            const typePrefix = message.type ? `[${message.type}] ` : '';
-
-            p.textContent = `${typePrefix}${sender}: ${content}`;
-            messages.appendChild(p);
-            messages.scrollTop = messages.scrollHeight;
-        }
-
-        function leaveRoom() {
-            if (!stompClient || !stompClient.connected) return;
-
-            stompClient.send("/pub/debate/leave", {}, JSON.stringify({
-                roomId: currentRoomId
-            }));
-
-            stompClient.disconnect(() => {
-                console.log("Disconnected from room " + currentRoomId);
-                document.getElementById('chat-box').style.display = 'none';
-                currentRoomId = null;
-                userId = null;
-            });
-        }
-
-        window.onload = loadRooms;
+    window.onload = loadRooms;
     </script>
 </body>
 </html>

--- a/src/main/resources/static/debateroom.html
+++ b/src/main/resources/static/debateroom.html
@@ -36,7 +36,7 @@
     <div style="border: 1px solid #ccc; padding: 10px; margin-bottom: 20px;">
         <h2>Join Debate Room</h2>
         <input type="text" id="join-room-id" placeholder="Room ID"><br>
-        <input type="text" id="join-user-id" placeholder="User ID"><br>
+        <!-- <input type="text" id="join-user-id" placeholder="User ID"><br> -->
         <select id="join-role">
             <option value="">-- Select Role --</option>
             <option value="SPEAKER">SPEAKER</option>
@@ -104,6 +104,20 @@
             .catch(err => console.error('방 생성 실패:', err));
         }
 
+        // function getAccessToken() {
+        //     // 로그인 시 저장해둔 액세스 토큰을 반환 (예: localStorage)
+        //     return localStorage.getItem('access_token');
+        // }
+        async function ensureAccessToken() {
+          let t = localStorage.getItem('access_token');
+          if (t) return t;
+          const res = await fetch('/auth/token', { method: 'POST', credentials: 'include' });
+          if (!res.ok) return null;
+          const { accessToken } = await res.json();
+          localStorage.setItem('access_token', accessToken);
+          return accessToken;
+        }
+
         function loadRooms() {
             fetch('/api/debate-rooms/all')
                 .then(response => response.json())
@@ -116,7 +130,8 @@
 
                         const joinButton = document.createElement('button');
                         joinButton.textContent = 'Join';
-                        joinButton.onclick = () => joinRoom(room.roomId);
+                        // 3) 방 리스트 Join 버튼: async + await (기본 AUDIENCE/A)
+                        joinButton.onclick = async () => { await joinRoom(room.roomId, 'AUDIENCE', 'A'); };
                         li.appendChild(joinButton);
 
                         roomList.appendChild(li);
@@ -127,35 +142,65 @@
                 });
         }
 
-        function joinRoom(roomId, userId, role, side) {
+        // 기존: function joinRoom(roomId, userId, role, side) {
+        async function joinRoom(roomId, role, side) {
+            role = role || 'AUDIENCE';
+            side = side || 'A';
             currentRoomId = roomId;
+
+            const token = await ensureAccessToken();
+            console.log("token:", token)
+            if (role === 'SPEAKER' && !token) {
+                alert('발언자로 참여하려면 로그인이 필요합니다.');
+                // 로그인 페이지로 이동 등
+                return;
+            }
 
             const socket = new SockJS('/ws-stomp');
             stompClient = Stomp.over(socket);
 
-            stompClient.connect({}, function (frame) {
+            // ★ 토큰을 CONNECT 헤더에 실어 보냄
+            const connectHeaders = token ? { Authorization: 'Bearer ' + token } : {};
+
+            stompClient.connect(connectHeaders, function (frame) {
                 console.log('Connected: ' + frame);
 
+                // 룸 브로드캐스트 구독
                 stompClient.subscribe('/sub/debate-room/' + roomId, function (message) {
-                    showMessage(JSON.parse(message.body));
+                const payload = JSON.parse(message.body);
+                showMessage(payload);
+
+                // 입장 성공 시 서버가 내려주는 사용자 정보로 UI 갱신
+                if (payload.type === 'JOIN_ACCEPTED') {
+                    const { userId: acceptedUserId, userName, role: joinedRole, side: joinedSide } = payload;
+
+                    document.getElementById('room-info').textContent = `RoomId: ${roomId}`;
+                    document.getElementById('user-info').textContent =
+                    `You are: ${userName} (#${acceptedUserId}) (${joinedRole}, side ${joinedSide})`;
+                    document.getElementById('chat-box').style.display = 'block';
+                }
+
+                if (payload.type === 'JOIN_REJECTED') {
+                    alert('입장 실패: ' + (payload.reason || 'unknown'));
+                }
                 });
 
-                stompClient.send("/pub/debate/join", {}, JSON.stringify({
-                    roomId: roomId,
-                    userId: userId,
-                    role: role,
-                    side: side
-                }));
-
-                document.getElementById('room-info').textContent = `RoomId: ${roomId}`;
-                document.getElementById('user-info').textContent = `You are: ${userId} (${role}, side ${side})`;
-                document.getElementById('chat-box').style.display = 'block';
-
+                // 참가자 목록 구독
                 stompClient.subscribe(`/sub/debate-room/${roomId}/participants`, function (message) {
-                    const participants = JSON.parse(message.body);
-                    console.log("📥 [단일방] 참가자 목록 수신:", participants);
-                    renderParticipants(participants);
+                const participants = JSON.parse(message.body);
+                console.log("📥 [단일방] 참가자 목록 수신:", participants);
+                renderParticipants(participants);
                 });
+
+                // ★ 조인 전송: userId는 보내지 않음 (서버가 Principal로 식별)
+                stompClient.send("/pub/debate/join", {}, JSON.stringify({
+                roomId: roomId,
+                role: role,
+                side: side
+                }));
+            }, function (err) {
+                console.error('STOMP error:', err);
+                alert('WebSocket 연결에 실패했습니다.');
             });
         }
 
@@ -169,36 +214,34 @@
             }
 
             participants.forEach(function (user) {
+                const displayName = user.userName || user.userId; // userName 우선
                 const li = document.createElement("li");
-                li.textContent = `👤 ${user.userId} (${user.role}, Side ${user.side})`;
+                li.textContent = `👤 ${displayName} (${user.role}, Side ${user.side})`;
                 list.appendChild(li);
             });
         }
 
-        function joinRoomFromForm() {
+        async function joinRoomFromForm() {
             const roomId = document.getElementById('join-room-id').value;
-            const userId = document.getElementById('join-user-id').value;
             const role = document.getElementById('join-role').value;
             const side = document.getElementById('join-side').value;
 
-            if (!roomId || !userId || !role || !side) {
-                alert("모든 항목을 입력해주세요.");
+            if (!roomId || !role || !side) {
+                alert("Room ID, Role, Side를 모두 선택/입력하세요.");
                 return;
             }
-
-            joinRoom(roomId, userId, role, side); // 기존 joinRoom 함수를 인자로 수정하세요
+            // 기존: joinRoom(roomId, userId, role, side);
+            joinRoom(roomId, role, side);
         }
 
         function sendMessage() {
             const messageInput = document.getElementById('message');
-            const roomId = document.getElementById('join-room-id').value;
-            const userId = document.getElementById('join-user-id').value;
             const content = messageInput.value.trim();
             if (!content) return;
 
             const message = {
                 roomId: currentRoomId,
-                sender: userId || 'user->',
+                // sender 제거
                 message: content
             };
 
@@ -231,8 +274,7 @@
             if (!stompClient || !stompClient.connected) return;
 
             stompClient.send("/pub/debate/leave", {}, JSON.stringify({
-                roomId: currentRoomId,
-                userId: userId
+                roomId: currentRoomId
             }));
 
             stompClient.disconnect(() => {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -35,7 +35,7 @@
     <a class="btn" href="/debateroom.html">Debate Room</a>
     <a class="btn" href="/participants.html">Participants</a>
     <a class="btn" href="/stompspeakingtest.html">Stomp Speaking Test</a>
-    <a class="btn" href="/oauth2-login-test.html">OAuth2 Login Test</a>
+    <a class="btn" href="/oauth2/test">OAuth2 Login Test</a>
     <a class="btn" href="/webrtc.html">Webrtc</a>
 </body>
 </html>

--- a/src/main/resources/static/participants.html
+++ b/src/main/resources/static/participants.html
@@ -110,12 +110,15 @@
                 const audienceCount = users.filter(u => u.role === "AUDIENCE").length;
 
                 const meta = roomMetaCache[roomId] || { maxSpeaker: 0, maxAudience: 0, title: "" };
-                const userInfo = users.map(u => `${u.userId} (${u.role}, Side ${u.side})`).join(", ");
+                const userInfo = users
+                    .map(u => `👤${u.userName} -- ${u.userId} (${u.role} · Side ${u.side})`)
+                    .join("<br>");
 
                 const li = document.createElement("li");
-                li.textContent =
+                li.innerHTML =
                     `🛖 Room ${roomId} ${meta.title ? `- ${meta.title} ` : ""}` +
-                    `| Speakers ${speakerCount}/${meta.maxSpeaker} · Audience ${audienceCount}/${meta.maxAudience} → ${userInfo}`;
+                    `| Speakers ${speakerCount}/${meta.maxSpeaker} · Audience ${audienceCount}/${meta.maxAudience}` +
+                    `<br>${userInfo}`;
                 list.appendChild(li);
             }
         }
@@ -146,7 +149,7 @@
             // 개별 사용자
             participants.forEach(user => {
                 const li = document.createElement("li");
-                li.textContent = `👤 ${user.userId} (${user.role}, Side ${user.side})`;
+                li.textContent = `👤 ${user.userName} (${user.role}, Side ${user.side})`;
                 list.appendChild(li);
             });
         }

--- a/src/main/resources/static/participants.html
+++ b/src/main/resources/static/participants.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Debate Room</title>
+    <title>Debate Room List</title>
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
 </head>


### PR DESCRIPTION
## 🔥*Pull requests*

## 📌 작업한 브랜치
- feature/#41

## ✨ 작업한 내용
### 서버(WebSocket/인증)
- `ChannelInterceptor`에서 STOMP `CONNECT` 헤더의 **Authorization: Bearer <JWT>** 파싱
  - 유효한 토큰이면 `AuthUserPrincipal(userId, userName, authorities)` 주입
  - 없거나 무효면 `GuestPrincipal` 주입 (게스트)
- `JwtKey`/`JwtProvider` 개선
  - `Keys.hmacShaKeyFor`로 HS256 키 생성 (32바이트 이상 강제)
  - `validateToken()` 원인 로그(만료/서명 등) + `parseClaims()` 공용화
  - `getUserId()` 타입 안전(Integer/Long/String) 지원, `getUsername()` subject 폴백
- `DebateController.join` 안정화
  - `RoomPrincipal`에서 **isAuth** 계산 → SPEAKER는 로그인 필수(`JOIN_REJECTED: auth_required`)
  - AUDIENCE는 로그인/비로그인 모두 허용
  - 에러 발생 시 `JOIN_REJECTED: server_error` 브로드캐스트
  - 한국어 로그 정비
- `ParticipantService.tryAddUserToRoomByPk` NPE 방지
  - `maxSpeaker`/`maxAudience`가 `null`이면 거절(명확 로그) 후 반환
  - Redis 저장 시 `Map.of(...)` → `HashMap`으로 변경해 **`userId=null` 허용**
  - `RoomUserInfo.userId`는 `Long`(래퍼) 사용

### 클라이언트(debateroom.html)
- `ensureAccessToken({ require })`
  - **SPEAKER일 때만 토큰 발급 시도** (AUDIENCE는 토큰 없이 게스트로 접속)
- STOMP `connectHeaders`
  - SPEAKER/토큰 있을 때만 `Authorization` 헤더 첨부
- **중복 수신(메시지 2번 찍힘) 해결**
  - 구독 핸들(`roomSub`, `participantsSub`) 저장 → 재입장/퇴장 시 `unsubscribe()`
  - 연결 중복 방지 플래그(`connectInFlight`)로 동시 연결 차단
- JOIN 응답 처리 강화
  - `nonce` 전송/매칭 + `selfInfoLocked`로 내 UI 1회만 갱신
- 기타
  - `showMessage`에서 `userName` 우선 표시
  - 참가자 렌더러/로그 보강

## 🧩 왜 필요한가 (원인)
- STOMP CONNECT에 Authorization 미첨부 또는 오래된 토큰 → 서버에서 게스트로 인식
- `Map.of(...)`가 `null`값을 허용하지 않아 **게스트(userId=null)** 에서 NPE
- 같은 토픽 **중복 구독**으로 채팅/알림이 **두 번씩** 수신
- `maxSpeaker/maxAudience`가 `null`일 때 `.intValue()` NPE

## ✅ 테스트 방법
1. **SPEAKER (로그인 상태)**
   - 브라우저 로그인 → 방 입장(역할=SPEAKER)
   - 기대: `[STOMP][DBG] jwt.validate=true`, `[JOIN_ACCEPTED]`, Redis 참가자 저장
2. **SPEAKER (비로그인)**
   - 토큰 없이 입장 시도
   - 기대: `JOIN_REJECTED: auth_required`
3. **AUDIENCE (비로그인/게스트)**
   - 토큰 없이 입장
   - 기대: `JOIN_ACCEPTED`, 사용자명 `게스트 xxxx`, Redis에 `userId=null` 저장됨
4. **중복 구독 확인**
   - 같은 탭에서 재입장/역할 변경
   - 기대: 채팅/알림이 **한 번만** 표시
5. **에러 가드**
   - DB에서 `maxSpeaker` 또는 `maxAudience`가 `null`인 방
   - 기대: 입장 거절 + 명확 로그, 서버 NPE 없음

## ⚙️ 배포/설정
- `jwt.secret`는 **32바이트 이상**(권장 64+) 고정 값 필요
- 토큰 발급 라우트(`/auth/token` 혹은 `/api/auth/token`)와 프론트 호출 경로 일치 확인
- DB 마이그레이션 없음

## 🔙 롤백 계획
- 문제가 생기면 이전 릴리즈 태그로 되돌림(`git revert` 권장)
- 급한 경우: 서비스 레벨에서 WebSocket 엔드포인트 비활성화 후 재배포

## 🔗 관련 이슈
- Resolves #41

## 👀 리뷰 요청사항
- Redis 트래커에서 `userId=null` 케이스 처리 확인
- `ChannelInterceptor`에서 principal 세팅/로깅 구조 OK 여부
- 재연결/역할 전환 시 구독 해제 로직(메모리 릭, 이벤트 중복) 체크
- 추가적으로 필요한 모니터링 포인트가 있으면 코멘트 부탁드립니다.
