### PR TITLE
Feat/#31 토론 결과, 토론 시작, 토론 종료 기능 추가

### DIFF
--- a/src/main/java/com/likelion/realtalk/domain/debate/api/AIController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/AIController.java
@@ -5,12 +5,12 @@ import com.likelion.realtalk.domain.debate.service.AiService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/debate/{roomUUID}/ai")
 public class AIController {

--- a/src/main/java/com/likelion/realtalk/domain/debate/api/AudienceController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/AudienceController.java
@@ -4,12 +4,12 @@ import com.likelion.realtalk.domain.debate.dto.AudienceTimerDto;
 import com.likelion.realtalk.domain.debate.service.AudienceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/debate/{roomUUID}/audiences")
 public class AudienceController {

--- a/src/main/java/com/likelion/realtalk/domain/debate/api/DebateController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/DebateController.java
@@ -1,6 +1,7 @@
 package com.likelion.realtalk.domain.debate.api;
 
 import com.likelion.realtalk.domain.debate.dto.DebatestartResponse;
+import com.likelion.realtalk.domain.debate.dto.DebateRoomTimerDto;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -239,6 +240,11 @@ public class DebateController {
         AiSummaryResponse response = debateRoomService.findAiSummaryById(pk);
         // AiSummaryResponse response = debateRoomService.findAiSummaryById(roomId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{roomUUID}/expire")
+    public ResponseEntity<DebateRoomTimerDto> getDebateRoomExpireTime(@PathVariable String roomUUID) {
+        return ResponseEntity.ok(debateRoomService.getDebateRoomExpireTime(roomUUID));
     }
 
     //status, at 변경해야하므로 POST

--- a/src/main/java/com/likelion/realtalk/domain/debate/api/DebateResultController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/DebateResultController.java
@@ -1,0 +1,23 @@
+package com.likelion.realtalk.domain.debate.api;
+
+import com.likelion.realtalk.domain.debate.dto.DebateResultDto;
+import com.likelion.realtalk.domain.debate.service.DebateResultService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/debate-results")
+public class DebateResultController {
+
+  private final DebateResultService debateResultService;
+
+  @GetMapping("/{roomUUID}")
+  public ResponseEntity<DebateResultDto> getDebateResult(@PathVariable String roomUUID) {
+    return ResponseEntity.ok(debateResultService.getDebateResult(roomUUID));
+  }
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/api/DebateStompController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/DebateStompController.java
@@ -1,0 +1,18 @@
+package com.likelion.realtalk.domain.debate.api;
+
+import com.likelion.realtalk.domain.debate.service.DebateRoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+@RequiredArgsConstructor
+@Controller
+public class DebateStompController {
+
+  private final DebateRoomService debateRoomService;
+
+  @MessageMapping("/debate/extend")
+  public void extendDebateRoomTime(String roomUUID) {
+    debateRoomService.extendDebateTime(roomUUID);
+  }
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/api/SpeakerController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/SpeakerController.java
@@ -1,14 +1,8 @@
 package com.likelion.realtalk.domain.debate.api;
 
-import com.likelion.realtalk.domain.debate.dto.DebateMessageDto;
-import com.likelion.realtalk.domain.debate.dto.DebateRoomDto;
 import com.likelion.realtalk.domain.debate.dto.SpeakerMessageDto;
 import com.likelion.realtalk.domain.debate.dto.SpeakerTimerDto;
-import com.likelion.realtalk.domain.debate.service.AiService;
-import com.likelion.realtalk.domain.debate.service.DebateResultService;
 import com.likelion.realtalk.domain.debate.service.SpeakerService;
-import com.likelion.realtalk.domain.debate.type.Side;
-import io.netty.util.internal.ThreadLocalRandom;
 import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,8 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class SpeakerController {
 
   private final SpeakerService speakerService;
-  private final AiService aiService;
-  private final DebateResultService  debateResultService;
 
   // 토론방 최초 입장 시 지난 발언 내용 조회 api
   @GetMapping
@@ -36,19 +28,6 @@ public class SpeakerController {
   @GetMapping("/expire")
   public ResponseEntity<SpeakerTimerDto> getSpeakerExpire(@PathVariable String roomUUID) {
     return ResponseEntity.ok(speakerService.getSpeakerExpire(roomUUID));
-  }
-
-  @GetMapping("/add")
-  public void addParticipant() {
-    ArrayList<Long> userIds = new ArrayList<>();
-    userIds.add(1L);
-    userIds.add(2L);
-    speakerService.setDebateRoom(new DebateRoomDto("1", 1L, userIds, "FAST"));
-  }
-
-  @GetMapping("/submit")
-  public void submitSpeech() {
-    speakerService.submitSpeech(new DebateMessageDto("1", 1L, "저는 무상교육에 반대합니다. 무상교육으로 인한 세금 부담이 커지기 때문입니다.", ThreadLocalRandom.current().nextBoolean() ? Side.A : Side.B, ""));
   }
 
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/api/SpeakerStompController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/SpeakerStompController.java
@@ -1,10 +1,7 @@
 package com.likelion.realtalk.domain.debate.api;
 import com.likelion.realtalk.domain.debate.dto.DebateMessageDto;
-import com.likelion.realtalk.domain.debate.dto.SpeakerMessageDto;
 import com.likelion.realtalk.domain.debate.service.RecordingService;
 import com.likelion.realtalk.domain.debate.service.SpeakerService;
-//import com.likelion.realtalk.domain.speaker.service.SpeakerStompService;
-//import com.likelion.realtalk.domain.speaker.service.SpeechToTextService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -35,6 +32,9 @@ public class SpeakerStompController {
    */
   @MessageMapping("/speaker/text")
   public void handleTextSpeak(DebateMessageDto payload) {
+    // 현재 발언 시간이 아닐 경우 예외 처리
+    speakerService.validateSpeaker(payload);
+
     log.info("텍스트 발언 수신: {}", payload.getMessage());
     log.info("user id: {}", payload.getUserId());
     log.info("room id: {}", payload.getRoomUUID());

--- a/src/main/java/com/likelion/realtalk/domain/debate/dto/DebateResultDto.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/dto/DebateResultDto.java
@@ -1,39 +1,60 @@
 package com.likelion.realtalk.domain.debate.dto;
 
-import lombok.Builder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.likelion.realtalk.domain.debate.type.DebateType;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
+@ToString
 @Getter
 public class DebateResultDto {
 
-  private String debateType;
-  private String title;
-  private String categoryName;
-  private float sideARate;
-  private float sideBRate;
-  private AiSummaryResultDto aiSummaryResult;
+  private DebateType debateType; // 토론 유형
+  private String title; // 토론 제목
+  private String categoryName; // 토론 카테고리
+  private double sideARate; // A측 비율
+  private double sideBCRate; // B측 비율
+  private Long totalCount; // 전체 참여자 수
+  private String sideA; // A측 이름
+  private String sideB; // B측 이름
+  private Long durationSeconds;
+  private AiSummaryResultDto aiSummaryResult; // ai 요약 결과
 
   @Getter
-  public class AiSummaryResultDto {
-    private String sideA;
-    private String sideB;
-    private String aiResult;
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class AiSummaryResultDto {
+    private static final String EMPTY_MSG = "발언 내용이 없습니다.";
+    private String sideA; // A측 요약 결과
+    private String sideB; // B측 요약 결과
+    private String aiResult; // 전체 요약 결과
 
-    public AiSummaryResultDto(String sideA, String sideB, String aiResult) {
-      this.sideA = sideA;
-      this.sideB = sideB;
-      this.aiResult = aiResult;
+    public static AiSummaryResultDto empty() {
+      return new AiSummaryResultDto(EMPTY_MSG, EMPTY_MSG, EMPTY_MSG);
     }
   }
 
-  @Builder
-  public DebateResultDto(String debateType, String title, String categoryName, float sideARate,
-      float sideBRate, AiSummaryResultDto aiSummaryResult) {
+  public DebateResultDto(DebateType debateType, String title, String categoryName, double sideARate,
+      double sideBCRate, Long totalCount, String sideA, String sideB, String aiSummaryResult,
+      Long durationSeconds) {
+    ObjectMapper objectMapper = new ObjectMapper();
     this.debateType = debateType;
     this.title = title;
     this.categoryName = categoryName;
     this.sideARate = sideARate;
-    this.sideBRate = sideBRate;
-    this.aiSummaryResult = aiSummaryResult;
+    this.sideBCRate = sideBCRate;
+    this.totalCount = totalCount;
+    this.sideA = sideA;
+    this.sideB = sideB;
+    this.durationSeconds = durationSeconds;
+    try {
+      this.aiSummaryResult = objectMapper.readValue(aiSummaryResult, AiSummaryResultDto.class);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/dto/DebateRoomDto.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/dto/DebateRoomDto.java
@@ -1,15 +1,18 @@
 package com.likelion.realtalk.domain.debate.dto;
 
+import com.likelion.realtalk.domain.debate.type.DebateType;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public class DebateRoomDto {
   private String roomUUID;
   private List<Long> userIds;
-  private String debateType;
+  private DebateType debateType;
 
-  public DebateRoomDto(String roomUUID, List<Long> userIds, String debateType) {
+  @Builder
+  public DebateRoomDto(String roomUUID, List<Long> userIds, DebateType debateType) {
     this.roomUUID = roomUUID;
     this.userIds = userIds;
     this.debateType = debateType;

--- a/src/main/java/com/likelion/realtalk/domain/debate/dto/DebateRoomDto.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/dto/DebateRoomDto.java
@@ -6,13 +6,11 @@ import lombok.Getter;
 @Getter
 public class DebateRoomDto {
   private String roomUUID;
-  private Long roomId;
   private List<Long> userIds;
   private String debateType;
 
-  public DebateRoomDto(String roomUUID, Long roomId, List<Long> userIds, String debateType) {
+  public DebateRoomDto(String roomUUID, List<Long> userIds, String debateType) {
     this.roomUUID = roomUUID;
-    this.roomId = roomId;
     this.userIds = userIds;
     this.debateType = debateType;
   }

--- a/src/main/java/com/likelion/realtalk/domain/debate/dto/DebateRoomTimerDto.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/dto/DebateRoomTimerDto.java
@@ -1,0 +1,14 @@
+package com.likelion.realtalk.domain.debate.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class DebateRoomTimerDto {
+  private String debateExpireTime;
+
+  @Builder
+  public DebateRoomTimerDto(String debateExpireTime) {
+    this.debateExpireTime = debateExpireTime;
+  }
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/entity/DebateRoom.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/entity/DebateRoom.java
@@ -5,6 +5,7 @@ import com.likelion.realtalk.domain.debate.type.DebateType;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
@@ -14,12 +15,15 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter //TODO: 준표 왈 : @Setter 없애야함
 @Entity
+@NoArgsConstructor
 public class DebateRoom {
 
     @Id
@@ -70,4 +74,31 @@ public class DebateRoom {
 
     @Column(name = "max_participants")
     private Long maxParticipants;
+
+    @Builder
+    public DebateRoom(Long userId, String title, String debateDescription,
+        Category category, String sideA, String sideB, Long durationSeconds, Long maxSpeaker,
+        Long maxAudience, DebateType debateType, DebateRoomStatus status, LocalDateTime startedAt,
+        LocalDateTime closedAt, Long maxParticipants) {
+        this.userId = userId;
+        this.title = title;
+        this.debateDescription = debateDescription;
+        this.category = category;
+        this.sideA = sideA;
+        this.sideB = sideB;
+        this.durationSeconds = durationSeconds;
+        this.maxSpeaker = maxSpeaker;
+        this.maxAudience = maxAudience;
+        this.debateType = debateType;
+        this.status = status;
+        this.startedAt = startedAt;
+        this.closedAt = closedAt;
+        this.maxParticipants = maxParticipants;
+    }
+
+    public void endDebate(LocalDateTime closedAt) {
+        this.closedAt = closedAt;
+        this.durationSeconds = Duration.between(this.startedAt, this.closedAt).toSeconds();
+        this.status = DebateRoomStatus.ended;
+    }
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/repository/DebateRedisRepository.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/repository/DebateRedisRepository.java
@@ -27,6 +27,8 @@ public class DebateRedisRepository {
   private static final String FAST_DEBATE_TYPE = "FAST";
   private static final Duration NORMAL_SPEAK_DURATION = Duration.ofMinutes(5);
   private static final Duration FAST_SPEAK_DURATION = Duration.ofSeconds(30);
+  private static final long FAST_DEBATE_DURATION = 1;
+  private static final long NORMAL_DEBATE_DURATION = 10;
 
   /* ======================= Value 저장 (TTL 포함) ======================= */
   public void putValueWithExpire(String key, String value, Duration duration) {
@@ -73,12 +75,8 @@ public class DebateRedisRepository {
     );
   }
 
-  public String getCurrentSpeakerExpire(String roomUUID) {
-    return redisTemplate.opsForValue().get(RedisKeyUtil.getExpireKey(roomUUID));
-  }
-
-  public String getAudienceExpire(String roomUUID) {
-    return redisTemplate.opsForValue().get(RedisKeyUtil.getAudienceExpireKey(roomUUID));
+  public String getRedisValue(String key) {
+    return redisTemplate.opsForValue().get(key);
   }
 
   public String getRoomField(String roomUUID, String key) {
@@ -115,6 +113,12 @@ public class DebateRedisRepository {
 
   public void deleteByKey(String key) {
     redisTemplate.delete(key);
+  }
+
+  public Duration getDebateTime(String roomUUID) {
+    String type = getRoomField(roomUUID, "debateType" );
+    long participantCount = (long) (getParticipants(roomUUID).size());
+    return Duration.ofMinutes((NORMAL_DEBATE_TYPE.equals(type) ? NORMAL_DEBATE_DURATION : FAST_DEBATE_DURATION) * participantCount);
   }
 
   /* ======================= Generic JSON 저장/조회 ======================= */

--- a/src/main/java/com/likelion/realtalk/domain/debate/repository/DebateRedisRepository.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/repository/DebateRedisRepository.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.likelion.realtalk.domain.debate.dto.AiSummaryDto;
+import com.likelion.realtalk.domain.debate.dto.RoomUserInfo;
 import com.likelion.realtalk.domain.debate.dto.SpeakerMessageDto;
 import com.likelion.realtalk.global.redis.RedisKeyUtil;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
@@ -61,9 +63,9 @@ public class DebateRedisRepository {
     Instant expireTime = Instant.now().plus(duration);
 
     // 한국 시간(KST)으로 변환 후 포맷
-    ZoneId kstZone = ZoneId.of("Asia/Seoul" );
+    ZoneId kstZone = ZoneId.of("Asia/Seoul");
     String expireTimeKST = expireTime.atZone(kstZone)
-        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss" ));
+        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
 
     putValueWithExpire(expireKey, expireTimeKST, duration);
 
@@ -97,7 +99,7 @@ public class DebateRedisRepository {
 
   // 토론방 타입 별 발언 시간 반환
   private Duration getSpeakDuration(String roomUUID) {
-    String type = getRoomField(roomUUID, "debateType" );
+    String type = getRoomField(roomUUID, "debateType");
     return NORMAL_DEBATE_TYPE.equals(type) ? NORMAL_SPEAK_DURATION : FAST_SPEAK_DURATION;
   }
 
@@ -111,20 +113,67 @@ public class DebateRedisRepository {
     }).orElseGet(ArrayList::new);
   }
 
+  public List<Long> getSpeakerUserIds(Long roomId) {
+    // speakers 조회
+    Set<String> speakersSet = redisTemplate.opsForSet()
+        .members(RedisKeyUtil.getSpeakersKey(roomId));
+
+    // waitingUsers 조회
+    Map<Object, Object> waitingUsers = redisTemplate.opsForHash()
+        .entries(RedisKeyUtil.getWaitingUsers(roomId));
+
+    if (speakersSet == null || speakersSet.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return speakersSet.stream().filter(waitingUsers::containsKey) // waitingUsers 맵에 해당 키가 존재하는지 확인
+        .map(key -> {
+          try {
+            String userInfoJson = (String) waitingUsers.get(key);
+            return objectMapper.readValue(userInfoJson, RoomUserInfo.class).getUserId();
+          } catch (JsonProcessingException e) {
+            return null;
+          }
+        }).filter(Objects::nonNull).collect(Collectors.toList());
+  }
+
+  public RoomUserInfo getSpeaker(Long roomId, Long userId) {
+    Map<Object, Object> waitingUsers = redisTemplate.opsForHash()
+        .entries(RedisKeyUtil.getWaitingUsers(roomId));
+
+    List<RoomUserInfo> userList = waitingUsers.values().stream().map(value -> {
+          try {
+            String jsonString = (String) value;
+            return objectMapper.readValue(jsonString, RoomUserInfo.class);
+          } catch (JsonProcessingException e) {
+            System.err.println("JSON 변환 실패: " + e.getMessage());
+            return null;
+          }
+        }).filter(Objects::nonNull) // null이 아닌 유효한 객체만 남김
+        .toList();
+
+    Optional<RoomUserInfo> firstUser = userList.stream().filter(f -> f.getUserId().equals(userId))
+        .findFirst();
+
+    return firstUser.orElse(null);
+  }
+
   public void deleteByKey(String key) {
     redisTemplate.delete(key);
   }
 
   public Duration getDebateTime(String roomUUID) {
-    String type = getRoomField(roomUUID, "debateType" );
+    String type = getRoomField(roomUUID, "debateType");
     long participantCount = (long) (getParticipants(roomUUID).size());
-    return Duration.ofMinutes((NORMAL_DEBATE_TYPE.equals(type) ? NORMAL_DEBATE_DURATION : FAST_DEBATE_DURATION) * participantCount);
+    return Duration.ofMinutes(
+        (NORMAL_DEBATE_TYPE.equals(type) ? NORMAL_DEBATE_DURATION : FAST_DEBATE_DURATION)
+            * participantCount);
   }
 
   /* ======================= Generic JSON 저장/조회 ======================= */
   public <T> void putJsonToHash(String key, String hashKey, T value) {
     if (hashKey == null) {
-      throw new RuntimeException("해당 토롱방의 turn 정보가 없습니다." );
+      throw new RuntimeException("해당 토롱방의 turn 정보가 없습니다.");
     }
     try {
       redisTemplate.opsForHash().put(key, hashKey, objectMapper.writeValueAsString(value));
@@ -135,7 +184,7 @@ public class DebateRedisRepository {
 
   public <T> Optional<T> readJsonFromHash(String key, String hashKey, TypeReference<T> typeRef) {
     if (hashKey == null) {
-      throw new RuntimeException("해당 토론방의 turn 정보가 없습니다." );
+      throw new RuntimeException("해당 토론방의 turn 정보가 없습니다.");
     }
     String json = redisTemplate.<String, String>opsForHash().get(key, hashKey);
     if (json == null || json.isEmpty()) {

--- a/src/main/java/com/likelion/realtalk/domain/debate/repository/DebateResultRepository.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/repository/DebateResultRepository.java
@@ -1,8 +1,39 @@
 package com.likelion.realtalk.domain.debate.repository;
 
+import com.likelion.realtalk.domain.debate.dto.DebateResultDto;
 import com.likelion.realtalk.domain.debate.entity.DebateResult;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface DebateResultRepository extends JpaRepository<DebateResult, Long> {
 
+  @Query("""
+                SELECT new com.likelion.realtalk.domain.debate.dto.DebateResultDto(
+                  room.debateType,
+                  room.title,
+                  c.categoryName,
+                  COALESCE(COUNT(CASE WHEN dp.side = 'A' THEN 1 END) * 1.0 / COUNT(dp.side), 0),
+                  COALESCE(COUNT(CASE WHEN dp.side = 'B' THEN 1 END) * 1.0 / COUNT(dp.side), 0),
+                  COUNT(dp.side),
+                  room.sideA,
+                  room.sideB,
+                  dr.aiSummary,
+                  room.durationSeconds
+                )
+                FROM DebateResult dr
+                LEFT JOIN dr.debateRoom room
+                LEFT JOIN room.category c
+                LEFT JOIN DebateParticipant dp ON dp.debateRoom = room
+                WHERE room.roomId = :roomId
+                GROUP BY
+                  room.debateType,
+                  room.title,
+                  c.categoryName,
+                  room.sideA,
+                  room.sideB,
+                  room.startedAt,
+                  room.closedAt,
+                  dr.aiSummary
+      """)
+  DebateResultDto findDebateresultByDebateRoomId(Long roomId);
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/service/AudienceService.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/service/AudienceService.java
@@ -17,7 +17,7 @@ public class AudienceService {
   public AudienceTimerDto getAudienceExpire(String roomUUID) {
     return AudienceTimerDto
         .builder()
-        .audienceExpireTime(debateRedisRepository.getAudienceExpire(roomUUID))
+        .audienceExpireTime(debateRedisRepository.getRedisValue(RedisKeyUtil.getAudienceExpireKey(roomUUID)))
         .build();
   }
 

--- a/src/main/java/com/likelion/realtalk/domain/debate/service/DebateRoomService.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/service/DebateRoomService.java
@@ -2,6 +2,7 @@ package com.likelion.realtalk.domain.debate.service;
 
 import com.likelion.realtalk.domain.category.entity.Category;
 import com.likelion.realtalk.domain.category.repository.CategoryRepository;
+import com.likelion.realtalk.domain.debate.dto.DebateRoomDto;
 import com.likelion.realtalk.domain.debate.dto.DebateRoomTimerDto;
 import com.likelion.realtalk.domain.debate.dto.DebatestartResponse;
 import com.likelion.realtalk.domain.debate.repository.DebateRedisRepository;
@@ -38,189 +39,203 @@ public class DebateRoomService {
   private final CategoryRepository categoryRepository;
   private final DebateRedisRepository debateRedisRepository;
   private final SimpMessageSendingOperations messagingTemplate;
+  private final SpeakerService speakerService;
   // private final StringRedisTemplate stringRedisTemplate; // ← 주입 추가
   // private final DebateEventPublisher debateEventPublisher;
 
-    private Long calculateElapsedSeconds(LocalDateTime startedAt) {
-        if (startedAt == null) return 0L;
-        return Duration.between(startedAt, LocalDateTime.now()).getSeconds();
+  private Long calculateElapsedSeconds(LocalDateTime startedAt) {
+    if (startedAt == null) {
+      return 0L;
+    }
+    return Duration.between(startedAt, LocalDateTime.now()).getSeconds();
+  }
+
+  public DebateRoom findRoomSummaryById(Long roomId) {
+    return debateRoomRepository.findById(roomId).orElse(null);
+  }
+
+  //AI 정리
+  public AiSummaryResponse findAiSummaryById(Long roomId) {
+    DebateRoom room = debateRoomRepository.findById(roomId)
+        .orElseThrow(() -> new RuntimeException("AI 결과물을 찾을 수 없습니다."));
+
+    return AiSummaryResponse.builder()
+        .roomId(room.getRoomId())
+        .title(room.getTitle())
+        .category(AiSummaryResponse.CategoryDto.builder()
+            .id(room.getCategory().getId())
+            .name("카테고리 이름은 추후 조회") // 카테고리 명 로직 추가 필요
+            .build())
+        .build();
+  }
+
+  //모든 토론방 조회
+  public List<DebateRoomResponse> findAllRooms() {
+    List<DebateRoom> rooms = debateRoomRepository.findAllWithCategory();
+    if (rooms.isEmpty()) {
+      return List.of();
     }
 
-    public DebateRoom findRoomSummaryById(Long roomId) {
-        return debateRoomRepository.findById(roomId).orElse(null);
+    // 1) PK 목록 준비
+    List<Long> pks = rooms.stream().map(DebateRoom::getRoomId).toList();
+
+    // 2) PK → UUID 일괄 조회
+    Map<Long, UUID> pkToUuid = roomIdMappingService.toUuidBatch(pks);
+
+    // 3) 매핑 누락 정책: 여기서는 누락 시 skip (원하시면 throw로 바꾸세요)
+    return rooms.stream()
+        .map(room -> {
+          UUID externalId = pkToUuid.get(room.getRoomId());
+          if (externalId == null) {
+            // throw new IllegalStateException("PK 매핑 없음: " + room.getRoomId());
+            return null; // skip 정책
+          }
+
+          Long currentSpeaker = redisRoomTracker.getCurrentSpeakers(room.getRoomId());
+          Long currentAudience = redisRoomTracker.getCurrentAudiences(room.getRoomId());
+          Long elapsedSeconds = calculateElapsedSeconds(room.getStartedAt());
+
+          return DebateRoomResponse.builder()
+              .roomId(externalId)
+              .title(room.getTitle())
+              .status(room.getStatus().name())
+              .category(DebateRoomResponse.CategoryDto.builder()
+                  .id(room.getCategory().getId())
+                  .name(room.getCategory().getCategoryName())
+                  .build())
+              .sideA(room.getSideA())
+              .sideB(room.getSideB())
+              .maxSpeaker(room.getMaxSpeaker())
+              .maxAudience(room.getMaxAudience())
+              .debateType(room.getDebateType())
+              .currentSpeaker(currentSpeaker)
+              .currentAudience(currentAudience)
+              .elapsedSeconds(elapsedSeconds)
+              .build();
+        })
+        .filter(Objects::nonNull) // skip 정책일 때만
+        .toList();
+  }
+
+  // roomId로 토론방 검색
+  public DebateRoomResponse findRoomById(UUID roomUuid) {
+    Long pk = roomIdMappingService.toPk(roomUuid);
+
+    DebateRoom room = debateRoomRepository.findById(pk)
+        .orElseThrow(() -> new RuntimeException("토론방을 찾을 수 없습니다."));
+
+    Long currentSpeaker = redisRoomTracker.getCurrentSpeakers(pk);
+    Long currentAudience = redisRoomTracker.getCurrentAudiences(pk);
+    Long elapsedSeconds = calculateElapsedSeconds(room.getStartedAt());
+
+    return DebateRoomResponse.builder()
+        .roomId(roomUuid) // ★ 여기! Long이 아니라 UUID를 넣어야 함
+        .title(room.getTitle())
+        .status(room.getStatus().name())
+        .category(DebateRoomResponse.CategoryDto.builder()
+            .id(room.getCategory().getId())
+            .name("카테고리 이름은 추후 조회")
+            .build())
+        .sideA(room.getSideA())
+        .sideB(room.getSideB())
+        .maxSpeaker(room.getMaxSpeaker())
+        .maxAudience(room.getMaxAudience())
+        .debateType(room.getDebateType())
+        .currentSpeaker(currentSpeaker)
+        .currentAudience(currentAudience)
+        .elapsedSeconds(elapsedSeconds)
+        .build();
+  }
+
+  // 토론방 만들기
+  public DebateRoom createRoom(CreateRoomRequest request) {
+    DebateRoom debateRoom = new DebateRoom();
+
+    debateRoom.setRoomId(request.getRoomId()); // 수동 설정 필요 없다면 생략
+    debateRoom.setUserId(request.getUserId());
+    debateRoom.setTitle(request.getTitle()); //토론 주제
+    debateRoom.setDebateDescription(request.getDebateDescription()); //토론 설명
+
+    Long categoryId = request.getCategory().getId();
+    Category category = categoryRepository.findById(categoryId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 카테고리 정보를 찾을 수 없습니다."));
+
+    // 카테고리 ID 추출
+    if (request.getCategory() != null) {
+      debateRoom.setCategory(category);
     }
 
-    //AI 정리
-    public AiSummaryResponse findAiSummaryById(Long roomId) {
-        DebateRoom room = debateRoomRepository.findById(roomId).orElseThrow(() -> new RuntimeException("AI 결과물을 찾을 수 없습니다."));
+    debateRoom.setSideA(request.getSideA()); // 토론 사이드 (찬성)
+    debateRoom.setSideB(request.getSideB()); // 토론 사이드 (반대)
 
-        return AiSummaryResponse.builder()
-                .roomId(room.getRoomId())
-                .title(room.getTitle())
-                .category(AiSummaryResponse.CategoryDto.builder()
-                        .id(room.getCategory().getId())
-                        .name("카테고리 이름은 추후 조회") // 카테고리 명 로직 추가 필요
-                        .build())
-                .build();
+    debateRoom.setDebateType(request.getDebateType()); // 토론 유형
+    debateRoom.setDurationSeconds(request.getDurationSeconds()); //토론 시간
+    debateRoom.setMaxSpeaker((long) request.getMaxSpeaker()); // 최대 발언자 수
+    debateRoom.setMaxAudience((long) request.getMaxAudience()); //최대 청중 수
+
+    debateRoom.setStatus(DebateRoomStatus.waiting); // enum 값 명확히 지정
+    debateRoom.setStartedAt(LocalDateTime.now());
+
+    // maxParticipants는 요청에 없으면 계산해서 넣어야 할 수도 있음
+    debateRoom.setMaxParticipants(
+        (long) (request.getMaxSpeaker() + request.getMaxAudience())
+    );
+
+    DebateRoom saved = debateRoomRepository.save(debateRoom);
+
+    UUID uuid = UUID.randomUUID();
+
+    // TODO: getID()
+    roomIdMappingService.put(uuid, saved.getRoomId());
+
+    return debateRoomRepository.save(debateRoom);
+  }
+
+  @Transactional
+  public DebatestartResponse startRoom(Long roomId, UUID roomUUID) {
+    int rows = debateRoomRepository.startIfWaiting(
+        roomId,
+        LocalDateTime.now(),
+        DebateRoomStatus.started,
+        DebateRoomStatus.waiting
+    );
+
+    if (rows == 0) {
+      if (!debateRoomRepository.existsById(roomId)) {
+        throw new CustomException(ErrorCode.NOT_FOUND) {
+        };
+      }
+      throw new CustomException(ErrorCode.ROOM_ALREADY_STARTED) {
+      };
     }
 
-    //모든 토론방 조회
-    public List<DebateRoomResponse> findAllRooms() {
-        List<DebateRoom> rooms = debateRoomRepository.findAllWithCategory();
-        if (rooms.isEmpty()) return List.of();
+    // 갱신된 엔티티 재조회 후 DTO 구성
+    DebateRoom room = debateRoomRepository.findById(roomId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND) {
+        });
 
-        // 1) PK 목록 준비
-        List<Long> pks = rooms.stream().map(DebateRoom::getRoomId).toList();
-
-        // 2) PK → UUID 일괄 조회
-        Map<Long, UUID> pkToUuid = roomIdMappingService.toUuidBatch(pks);
-
-        // 3) 매핑 누락 정책: 여기서는 누락 시 skip (원하시면 throw로 바꾸세요)
-        return rooms.stream()
-            .map(room -> {
-                UUID externalId = pkToUuid.get(room.getRoomId());
-                if (externalId == null) {
-                    // throw new IllegalStateException("PK 매핑 없음: " + room.getRoomId());
-                    return null; // skip 정책
-                }
-
-                Long currentSpeaker  = redisRoomTracker.getCurrentSpeakers(room.getRoomId());
-                Long currentAudience = redisRoomTracker.getCurrentAudiences(room.getRoomId());
-                Long elapsedSeconds  = calculateElapsedSeconds(room.getStartedAt());
-
-                return DebateRoomResponse.builder()
-                        .roomId(externalId)
-                        .title(room.getTitle())
-                        .status(room.getStatus().name())
-                        .category(DebateRoomResponse.CategoryDto.builder()
-                                .id(room.getCategory().getId())
-                                .name(room.getCategory().getCategoryName())
-                                .build())
-                        .sideA(room.getSideA())
-                        .sideB(room.getSideB())
-                        .maxSpeaker(room.getMaxSpeaker())
-                        .maxAudience(room.getMaxAudience())
-                        .debateType(room.getDebateType())
-                        .currentSpeaker(currentSpeaker)
-                        .currentAudience(currentAudience)
-                        .elapsedSeconds(elapsedSeconds)
-                        .build();
-            })
-            .filter(Objects::nonNull) // skip 정책일 때만
-            .toList();
+    DebateRoomResponse.CategoryDto cat = null;
+    if (room.getCategory() != null) {
+      cat = DebateRoomResponse.CategoryDto.builder()
+          .id(room.getCategory().getId())
+          .name(room.getCategory().getCategoryName())
+          .build();
     }
 
-    // roomId로 토론방 검색
-    public DebateRoomResponse findRoomById(UUID roomUuid) {
-        Long pk = roomIdMappingService.toPk(roomUuid);
+    // 전체 토론 시작
+    startDebateTime(roomUUID, room);
 
-        DebateRoom room = debateRoomRepository.findById(pk)
-            .orElseThrow(() -> new RuntimeException("토론방을 찾을 수 없습니다."));
+    speakerService.setDebateRoom(DebateRoomDto.builder()
+        .roomUUID(roomUUID.toString())
+        .userIds(debateRedisRepository.getSpeakerUserIds(roomId))
+        .debateType(room.getDebateType())
+        .build());
 
-        Long currentSpeaker  = redisRoomTracker.getCurrentSpeakers(pk);
-        Long currentAudience = redisRoomTracker.getCurrentAudiences(pk);
-        Long elapsedSeconds  = calculateElapsedSeconds(room.getStartedAt());
-
-        return DebateRoomResponse.builder()
-                .roomId(roomUuid) // ★ 여기! Long이 아니라 UUID를 넣어야 함
-                .title(room.getTitle())
-                .status(room.getStatus().name())
-                .category(DebateRoomResponse.CategoryDto.builder()
-                        .id(room.getCategory().getId())
-                        .name("카테고리 이름은 추후 조회")
-                        .build())
-                .sideA(room.getSideA())
-                .sideB(room.getSideB())
-                .maxSpeaker(room.getMaxSpeaker())
-                .maxAudience(room.getMaxAudience())
-                .debateType(room.getDebateType())
-                .currentSpeaker(currentSpeaker)
-                .currentAudience(currentAudience)
-                .elapsedSeconds(elapsedSeconds)
-                .build();
-    }
-
-    // 토론방 만들기
-    public DebateRoom createRoom(CreateRoomRequest request) {
-        DebateRoom debateRoom = new DebateRoom();
-
-        debateRoom.setRoomId(request.getRoomId()); // 수동 설정 필요 없다면 생략
-        debateRoom.setUserId(request.getUserId());
-        debateRoom.setTitle(request.getTitle()); //토론 주제
-        debateRoom.setDebateDescription(request.getDebateDescription()); //토론 설명
-
-        Long categoryId = request.getCategory().getId();
-        Category category = categoryRepository.findById(categoryId).orElseThrow(() -> new IllegalArgumentException("해당 카테고리 정보를 찾을 수 없습니다."));
-
-        // 카테고리 ID 추출
-        if (request.getCategory() != null) {
-            debateRoom.setCategory(category);
-        }
-
-        debateRoom.setSideA(request.getSideA()); // 토론 사이드 (찬성)
-        debateRoom.setSideB(request.getSideB()); // 토론 사이드 (반대)
-
-        debateRoom.setDebateType(request.getDebateType()); // 토론 유형
-        debateRoom.setDurationSeconds(request.getDurationSeconds()); //토론 시간
-        debateRoom.setMaxSpeaker((long) request.getMaxSpeaker()); // 최대 발언자 수
-        debateRoom.setMaxAudience((long) request.getMaxAudience()); //최대 청중 수
-
-        debateRoom.setStatus(DebateRoomStatus.waiting); // enum 값 명확히 지정
-        debateRoom.setStartedAt(LocalDateTime.now());
-
-        // maxParticipants는 요청에 없으면 계산해서 넣어야 할 수도 있음
-        debateRoom.setMaxParticipants(
-            (long) (request.getMaxSpeaker() + request.getMaxAudience())
-        );
-
-        DebateRoom saved = debateRoomRepository.save(debateRoom);
-
-        UUID uuid = UUID.randomUUID();
-
-        // TODO: getID()
-        roomIdMappingService.put(uuid, saved.getRoomId());
-
-        return debateRoomRepository.save(debateRoom);
-    }
-
-    @Transactional
-    public DebatestartResponse startRoom(Long roomId, UUID roomUUID) {
-        int rows = debateRoomRepository.startIfWaiting(
-            roomId,
-            LocalDateTime.now(),
-            DebateRoomStatus.started,
-            DebateRoomStatus.waiting
-        );
-
-        if (rows == 0) {
-            if (!debateRoomRepository.existsById(roomId)) {
-                throw new CustomException(ErrorCode.NOT_FOUND) {};
-            }
-            throw new CustomException(ErrorCode.ROOM_ALREADY_STARTED) {};
-        }
-
-        // 갱신된 엔티티 재조회 후 DTO 구성
-        DebateRoom room = debateRoomRepository.findById(roomId)
-            .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND) {});
-
-        DebateRoomResponse.CategoryDto cat = null;
-        if (room.getCategory() != null) {
-            cat = DebateRoomResponse.CategoryDto.builder()
-                .id(room.getCategory().getId())
-                .name(room.getCategory().getCategoryName())
-                .build();
-        }
-
-      // 전체 토론 시작
-      startDebateTime(roomUUID, room);
-
-      // TODO. 발언 타이머 시작
-
-        return DebatestartResponse.builder()
-            .status(room.getStatus() != null ? room.getStatus().name() : null)
-            .startedAt(room.getStartedAt())                 // 시작 시각 포함
-            .build();
-    }
+    return DebatestartResponse.builder()
+        .status(room.getStatus() != null ? room.getStatus().name() : null)
+        .startedAt(room.getStartedAt())                 // 시작 시각 포함
+        .build();
+  }
 
   public void startDebateTime(UUID roomUUID, DebateRoom debateRoom) {
     // 전체 토론 타이머 설정

--- a/src/main/java/com/likelion/realtalk/domain/debate/service/RecordingService.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/service/RecordingService.java
@@ -27,6 +27,9 @@ public class RecordingService {
   private final SpeakerService speakerService;
 
   public void handleControl(DebateMessageDto payload) {
+    // 현재 발언 시간이 아닐 경우 예외 처리
+    speakerService.validateSpeaker(payload);
+
     final Long userId = payload.getUserId();
     final String roomUUID = payload.getRoomUUID();
     final String mode = payload.getMode();

--- a/src/main/java/com/likelion/realtalk/global/redis/RedisKeyExpiredListener.java
+++ b/src/main/java/com/likelion/realtalk/global/redis/RedisKeyExpiredListener.java
@@ -1,6 +1,7 @@
 package com.likelion.realtalk.global.redis;
 
 import com.likelion.realtalk.domain.debate.service.AudienceService;
+import com.likelion.realtalk.domain.debate.service.DebateRedisService;
 import com.likelion.realtalk.domain.debate.service.SpeakerService;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
@@ -12,12 +13,14 @@ public class RedisKeyExpiredListener extends KeyExpirationEventMessageListener {
 
   private final SpeakerService debateService;
   private final AudienceService audienceService;
+  private final DebateRedisService debateRedisService;
 
   public RedisKeyExpiredListener(RedisMessageListenerContainer listenerContainer,
-      SpeakerService debateService, AudienceService audienceService) {
+      SpeakerService debateService, AudienceService audienceService, DebateRedisService debateRedisService) {
     super(listenerContainer);
     this.debateService = debateService;
     this.audienceService = audienceService;
+    this.debateRedisService = debateRedisService;
   }
 
   @Override
@@ -30,6 +33,9 @@ public class RedisKeyExpiredListener extends KeyExpirationEventMessageListener {
     } else if (expiredKey.endsWith("audienceExpire" )) {
       // 의논 시간 종료 시 빈 문자열로 넘김
       debateService.startNextSpeaker(roomUUID);
+    } else if (expiredKey.endsWith("debateRoomExpire")) {
+      // 토론 종료
+      debateRedisService.endDebate(roomUUID);
     }
   }
 }

--- a/src/main/java/com/likelion/realtalk/global/redis/RedisKeyUtil.java
+++ b/src/main/java/com/likelion/realtalk/global/redis/RedisKeyUtil.java
@@ -25,4 +25,12 @@ public class RedisKeyUtil {
   public static String getAiSummariesKey(String roomUUID) {
     return "room:" + roomUUID + ":aiSummaries";
   }
+
+  public static String getSpeakersKey(Long roomId) {
+    return "debateRoom:" + roomId + ":speakers";
+  }
+
+  public static String getWaitingUsers(Long roomId) {
+    return "debateRoom:" + roomId + ":waitingUsers";
+  }
 }

--- a/src/main/java/com/likelion/realtalk/global/redis/RedisKeyUtil.java
+++ b/src/main/java/com/likelion/realtalk/global/redis/RedisKeyUtil.java
@@ -14,6 +14,10 @@ public class RedisKeyUtil {
     return "room:" + roomUUID + ":audienceExpire";
   }
 
+  public static String getDebateRoomExpire(String roomUUID) {
+    return "room:" + roomUUID + ":debateRoomExpire";
+  }
+
   public static String getSpeechesKey(String roomUUID) {
     return "room:" + roomUUID + ":speeches";
   }


### PR DESCRIPTION
## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- feature/#31

📄  **작업한 내용**
토론 시작/종료, 결과 기능 추가
- DebateResult, Category 엔티티 완성
- DebateResult DB 저장
- 토론 결론 저장 시 redis에 삭제 필요한 데이터 삭제
- 발언자 WebSocket 연결 해제 시 발언 순서 조정 기능 추가
- 토론 종료 타이머 설정
- 토론 시간 연장
## 💻 관련 이슈
- Resolved: #31 
