### PR TITLE
fix: 배포 시 GCP 키 파일 마운트 부분 임시 처리

### DIFF
--- a/deploy/deploy-single.sh
+++ b/deploy/deploy-single.sh
@@ -57,8 +57,8 @@ docker run -d --name "${CONTAINER_NAME}" \
   -e JWT_SECRET="${JWT_SECRET}" \
   -e BASE_URL="${BASE_URL}" \
   -e FRONTEND_URL="${FRONTEND_URL}" \
-  -e GCP_KEY_PATH="/keys/gcp.json" \
-  --mount type=volume,source=gcp-keys,target=/keys,readonly=true \
+  # -e GCP_KEY_PATH="/keys/gcp.json" \ cicd가 돌아야 웹소켓 연결 테스트를 하기 때문에 이부분 주석처리 하겠습니다
+  # --mount type=volume,source=gcp-keys,target=/keys,readonly=true \
   "${IMAGE}"
 
 # 2-3) 외부(호스트)에서 최종 헬스체크 (최대 30초)


### PR DESCRIPTION
- 일단 cicd가 돌아야 웹소켓 테스트가 가능해서 임시 주석처리 진행하였습니다


📄  **작업한 내용**
<!-- 작업에 대한 간략한 설명 -->
- deploy-single.sh 부분에 키파일 마운트 하는 부분을 임시 주석처리 하였습니다