### PR TITLE
fix: deploy-single.sh 문법 오류

### DIFF
--- a/deploy/deploy-single.sh
+++ b/deploy/deploy-single.sh
@@ -57,9 +57,11 @@ docker run -d --name "${CONTAINER_NAME}" \
   -e JWT_SECRET="${JWT_SECRET}" \
   -e BASE_URL="${BASE_URL}" \
   -e FRONTEND_URL="${FRONTEND_URL}" \
-  # -e GCP_KEY_PATH="/keys/gcp.json" \ (cicd가 돌아야 웹소켓 연결 테스트를 하기 때문에 이부분 주석처리 하겠습니다)
-  # --mount type=volume,source=gcp-keys,target=/keys,readonly=true \
   "${IMAGE}"
+
+  # -e GCP_KEY_PATH="/keys/gcp.json" (cicd가 돌아야 웹소켓 연결 테스트를 하기 때문에 이부분 주석처리 하겠습니다)
+  # --mount type=volume,source=gcp-keys,target=/keys,readonly=true
+  # "${IMAGE}"
 
 # 2-3) 외부(호스트)에서 최종 헬스체크 (최대 30초)
 echo "[배포] 최종 헬스체크 대기..."
@@ -100,9 +102,12 @@ if [[ "${FINAL_OK}" != true ]]; then
       -e JWT_SECRET="${JWT_SECRET}" \
       -e BASE_URL="${BASE_URL}" \
       -e FRONTEND_URL="${FRONTEND_URL}" \
-      # -e GCP_KEY_PATH="/keys/gcp.json" \ (cicd가 돌아야 웹소켓 연결 테스트를 하기 때문에 이부분 주석처리 하겠습니다)
-      # --mount type=volume,source=gcp-keys,target=/keys,readonly=true \
       "${PREV_IMAGE_ID}"
+
+      # -e GCP_KEY_PATH="/keys/gcp.json" (cicd가 돌아야 웹소켓 연결 테스트를 하기 때문에 이부분 주석처리 하겠습니다)
+      # --mount type=volume,source=gcp-keys,target=/keys,readonly=true
+      # "${PREV_IMAGE_ID}"
+
   else
     echo "[배포] 이전 이미지 정보가 없어 롤백 불가"
   fi


### PR DESCRIPTION
[deploy-single.sh]
2-2) 새 이미지로 실제 서비스 컨테이너 기동
.
.
(1) -e GCP_KEY_PATH="/keys/gcp.json" \
(2) --mount type=volume,source=gcp-keys,target=/keys,readonly=true
.
.
(3) -e GCP_KEY_PATH="/keys/gcp.json
(4) --mount type=volume,source=gcp-keys,target=/keys,readonly=true
이렇게 4개 주석처리 하였습니다

[deploy.yml]
(1) git reset --hard HEAD
깃 충돌이 나서 이 옵션 추가하였습니다