### PR TITLE
feat(redis): 서버 기동 시 참가자 관련 Redis 키 자동 정리 기능 추가

### DIFF
--- a/src/main/java/com/likelion/realtalk/domain/debate/boot/RedisCleanupOnBoot.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/boot/RedisCleanupOnBoot.java
@@ -1,0 +1,22 @@
+package com.likelion.realtalk.domain.debate.boot;
+
+import com.likelion.realtalk.domain.debate.service.RedisParticipantsCleanupService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component // ← 항상 실행 (프로퍼티 조건 없이)
+@RequiredArgsConstructor
+public class RedisCleanupOnBoot implements ApplicationRunner {
+
+    private final RedisParticipantsCleanupService cleanup;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        long n = cleanup.cleanupAllParticipantsKeys();
+        log.info("[Redis] Cleaned participant keys on boot: {} keys", n);
+    }
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/service/RedisParticipantsCleanupService.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/service/RedisParticipantsCleanupService.java
@@ -1,0 +1,82 @@
+package com.likelion.realtalk.domain.debate.service;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisParticipantsCleanupService {
+
+    private final StringRedisTemplate redis;
+
+    private static final List<String> PATTERNS = List.of(
+        "debateRoom:*:waitingUsers",
+        "debateRoom:*:audiences",
+        "debateRoom:*:speakers",
+        "debateRoom:*:sessions" // 사용 중일 때만 의미 있음
+    );
+
+    /** 전체 방의 참가자 관련 키를 모두 삭제 (비동기 UNLINK) */
+    public long cleanupAllParticipantsKeys() {
+        long total = 0;
+        for (String pattern : PATTERNS) {
+            total += unlinkByScan(pattern);
+        }
+        return total;
+    }
+
+    /** 특정 방(pk)의 참가자 관련 키만 삭제 */
+    public long cleanupParticipantsByPk(Long pk) {
+        List<String> keys = List.of(
+            "debateRoom:" + pk + ":waitingUsers",
+            "debateRoom:" + pk + ":audiences",
+            "debateRoom:" + pk + ":speakers",
+            "debateRoom:" + pk + ":sessions"
+        );
+        return redis.execute((RedisConnection conn) -> {
+            byte[][] arr = keys.stream()
+                .map(k -> k.getBytes(StandardCharsets.UTF_8))
+                .toArray(byte[][]::new);
+            // UNLINK(비동기) → 블로킹 줄임. 즉시 삭제 원하면 conn.del(arr);
+            Long n = conn.unlink(arr);
+            return n == null ? 0L : n;
+        });
+    }
+
+    /** 패턴으로 SCAN하여 모은 뒤 UNLINK */
+    private long unlinkByScan(String pattern) {
+        List<byte[]> toDelete = new ArrayList<>(1024);
+
+        Long deleted = redis.execute((RedisConnection conn) -> {
+            ScanOptions opts = ScanOptions.scanOptions()
+                .match(pattern)
+                .count(1000)
+                .build();
+
+            try (Cursor<byte[]> cur = conn.scan(opts)) {
+                while (cur.hasNext()) {
+                    toDelete.add(cur.next());
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("SCAN failed for pattern " + pattern, e);
+            }
+
+            if (toDelete.isEmpty()) return 0L;
+
+            byte[][] arr = toDelete.toArray(byte[][]::new);
+            Long n = conn.unlink(arr); // 비동기 해제
+            return n == null ? 0L : n;
+        });
+
+        return deleted == null ? 0L : deleted;
+    }
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/websocket/StompDisconnectListener.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/websocket/StompDisconnectListener.java
@@ -1,0 +1,50 @@
+package com.likelion.realtalk.domain.debate.websocket;
+
+import com.likelion.realtalk.domain.debate.dto.RoomUserInfo;
+import com.likelion.realtalk.domain.debate.service.ParticipantService;
+import com.likelion.realtalk.domain.debate.service.RedisRoomTracker;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompDisconnectListener implements ApplicationListener<SessionDisconnectEvent> {
+
+    private final RedisRoomTracker redisRoomTracker;
+    private final ParticipantService participantService;
+
+    @Override
+    public void onApplicationEvent(SessionDisconnectEvent event) {
+        String sessionId = event.getSessionId();
+        if (sessionId == null) return;
+
+        // 1) 모든 방 PK 스캔
+        Set<Long> pks = redisRoomTracker.getAllRoomPks();
+        if (pks == null || pks.isEmpty()) return;
+
+        for (Long pk : pks) {
+            // 2) 이 방에 해당 세션이 있는지 확인
+            RoomUserInfo info = redisRoomTracker.findBySession(pk, sessionId);
+            if (info == null) continue;
+
+            String subjectId = info.getSubjectId();
+
+            // 3) Redis에서 세션/참가자 정리
+            redisRoomTracker.removeSession(pk, sessionId);
+
+            // 4) 메모리/브로드캐스트 정리
+            participantService.removeUserFromRoom(pk, subjectId);
+            participantService.broadcastParticipantsSpeaker(pk);
+            participantService.broadcastAllRooms();
+
+            log.debug("Disconnected cleanup: pk={}, sessionId={}, subjectId={}", pk, sessionId, subjectId);
+            break; // 찾았으면 종료
+        }
+    }
+}


### PR DESCRIPTION
- RedisParticipantsCleanupService 추가: debateRoom:*:waitingUsers, debateRoom:*:audiences, debateRoom:*:speakers, debateRoom:*:sessions 키 정리 메서드 제공
- RedisCleanupOnBoot 컴포넌트 추가: 서버 기동 시 참가자 관련 키 자동 삭제
- room:uuid:*, room:pk:* 매핑 키는 유지하도록 처리
- 세션 끊김 리스너(StompDisconnectListener) 구현: SessionDisconnectEvent 수신 후 Redis/메모리/브로드캐스트에서 세션 자동 정리
- join 시 세션 기반 바인딩 저장 로직 추가 (sessionId → pk, subjectId 추적 가능)
- leave 처리 시 수동 호출뿐 아니라 브라우저 닫힘/새로고침에도 자동 정리되도록 개선

## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- feature/#91

📄  **작업한 내용**

## 🚨 참고 사항

## 💻 관련 이슈
- Resolved: #91

## 💬 리뷰 요구사항 (선택)