### PR TITLE
Fix/#98 토론방 랜덤 매칭 오류

### DIFF
--- a/src/main/java/com/likelion/realtalk/domain/debate/repository/DebateRoomRepository.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/repository/DebateRoomRepository.java
@@ -30,9 +30,10 @@ public interface DebateRoomRepository extends JpaRepository<DebateRoom, Long> {
   List<DebateRoom> findAllWithCategory();
 
   @Query("""
-        select r from DebateRoom r join fetch r.category
-         where r.category.id = :categoryId
-           and r.status = 'ACTIVE'
-      """)
-  List<DebateRoom> pickOneByCategory(@Param("categoryId") Long categoryId);
+        select r from DebateRoom r
+        join fetch r.category c
+        where c.id = :categoryId
+        and r.status in ("waiting", "started")
+    """)
+  List<DebateRoom> findByCategoryAndStatus(@Param("categoryId") Long categoryId);
 }

--- a/src/main/java/com/likelion/realtalk/domain/debate/service/DebateRoomMatchService.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/service/DebateRoomMatchService.java
@@ -4,22 +4,20 @@ import com.likelion.realtalk.domain.debate.dto.DebateRoomResponse;
 import com.likelion.realtalk.domain.debate.entity.DebateRoom;
 import com.likelion.realtalk.domain.debate.repository.DebateRoomRepository;
 import java.time.Duration;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class DebateRoomMatchService {
 
   private final DebateRoomRepository debateRoomRepository;
@@ -27,42 +25,74 @@ public class DebateRoomMatchService {
   private final RedisRoomTracker redisRoomTracker;
 
   public DebateRoomResponse matchOne(Long categoryId) {
-    // 1) 후보 방: 해당 카테고리 + ACTIVE
-    List<DebateRoom> rooms = debateRoomRepository.pickOneByCategory(categoryId);
+    // 1) 후보 방: 해당 카테고리의 waiting/started 상태의 방 후보 조회
+    List<DebateRoom> rooms = debateRoomRepository.findByCategoryAndStatus(categoryId);
+    log.info("조회한 방 리스트 크기: {}", rooms.size());
     if (rooms == null || rooms.isEmpty()) {
-      throw new NoSuchElementException("해당 카테고리의 ACTIVE 방이 없습니다. categoryId=" + categoryId);
+      throw new NoSuchElementException("해당 카테고리의 토론방이 없습니다. categoryId=" + categoryId);
     }
 
-    // 2) Redis 현재 인원으로 "입장 가능" 필터
-    List<DebateRoom> candidates = new ArrayList<>();
-    for (DebateRoom r : rooms) {
-      long curSpeaker = redisRoomTracker.getCurrentSpeakers(r.getRoomId());
-      long curAudience = redisRoomTracker.getCurrentAudiences(r.getRoomId());
-      long maxSpeaker = nz(r.getMaxSpeaker());
-      long maxAudience = nz(r.getMaxAudience());
+    // 2) Redis 현재 인원으로 "입장 가능" 필터 중 청중 수 가장 많은 방 선택
+    DebateRoom picked = null;
+    long pickedCurSpeaker = 0L;
+    long pickedCurAudience = 0L;
 
-      if (curSpeaker < maxSpeaker || curAudience < maxAudience) {
-        candidates.add(r);
+    for (DebateRoom r : rooms) {
+      long curAudience = redisRoomTracker.getCurrentAudiences(r.getRoomId());
+      long maxAudience = nz(r.getMaxAudience());
+      log.info("방 ID: {}, 현재 청중 수: {}, 최대 청중 수: {}", r.getRoomId(), curAudience, maxAudience);
+
+      // 청중석 만석이면 다음 방으로
+      if (curAudience >= maxAudience) {
+        log.info("방 ID: {} 청중석 만석으로 건너뜀", r.getRoomId());
+        continue;
+      }
+
+      long curSpeaker = Long.MIN_VALUE;
+
+      // 타이브레이커에서 speaker 수가 필요할 수 있으므로, 동률일 때만 lazy 조회 보정
+      if (picked != null && curAudience == pickedCurAudience) {
+        curSpeaker = redisRoomTracker.getCurrentSpeakers(r.getRoomId());
+        if (pickedCurSpeaker == Long.MIN_VALUE) {
+          pickedCurSpeaker = redisRoomTracker.getCurrentSpeakers(picked.getRoomId());
+        }
+      }
+
+      if (picked == null
+          || curAudience > pickedCurAudience
+          || (curAudience == pickedCurAudience && curSpeaker < pickedCurSpeaker)
+          || (curAudience == pickedCurAudience && curSpeaker == pickedCurSpeaker && r.getRoomId() < picked.getRoomId())) {
+        String reason = picked == null ? "첫 후보 방" :
+            curAudience > pickedCurAudience ? "청중 수 많음" :
+            (curAudience == pickedCurAudience && curSpeaker < pickedCurSpeaker) ? "스피커 수 적음" :
+            "roomId 작은 방";
+        log.info("후보 방 갱신: 이전 방 ID: {}, 새 방 ID: {}, 이유: {}", picked == null ? "없음" : picked.getRoomId(), r.getRoomId(), reason);
+        picked = r;
+        pickedCurSpeaker = curSpeaker;
+        pickedCurAudience = curAudience;
       }
     }
-    if (candidates.isEmpty()) {
-      throw new NoSuchElementException("해당 카테고리의 ACTIVE 방 중 입장 가능한 방이 없습니다. categoryId=" + categoryId);
+
+    if (picked == null) {
+      throw new NoSuchElementException(
+          "해당 카테고리의 대기/시작 중인 방 중 입장 가능한 방이 없습니다. categoryId=" + categoryId);
     }
-
-    // 3) 후보 중 랜덤 선택
-    DebateRoom picked = candidates.get(ThreadLocalRandom.current().nextInt(candidates.size()));
-
-    // 4) PK -> UUID 매핑
+    // 3) PK -> UUID 매핑
     UUID roomUuid = roomIdMappingService.toUuid(picked.getRoomId());
+    log.info("최종 선택된 방 ID: {}, UUID: {}, currentSpeaker: {}, currentAudience: {}", picked.getRoomId(), roomUuid, pickedCurSpeaker, pickedCurAudience);
 
-    // 5) Redis에서 최종 카운트 재조회 (선택 사항: 위에서 구한 값 재사용해도 무방)
-    long currentSpeaker  = redisRoomTracker.getCurrentSpeakers(picked.getRoomId());
-    long currentAudience = redisRoomTracker.getCurrentAudiences(picked.getRoomId());
+    // 4) Redis에서 최종 카운트 재조회 대신 캐시 값 사용
+    long currentSpeaker  = pickedCurSpeaker;
+    long currentAudience = pickedCurAudience;
 
-    // 6) 경과 시간(초) 계산 (방 전체 진행 시간)
-    long elapsedSeconds = calculateElapsedSeconds(picked.getStartedAt());
+    // 5) 경과 시간(초) 계산 (waiting 상태는 0, started만 계산)
+    String st = picked.getStatus() == null ? null : picked.getStatus().name();
+    long elapsedSeconds = ("waiting".equalsIgnoreCase(st))
+        ? 0L
+        : calculateElapsedSeconds(picked.getStartedAt());
+    log.info("경과 시간(초) 계산 결과: {}", elapsedSeconds);
 
-    // 7) findRoomById와 동일 형식으로 응답 빌드
+    // 6) findRoomById와 동일 형식으로 응답 빌드
     return DebateRoomResponse.builder()
         .roomId(roomUuid) // ★ UUID
         .title(picked.getTitle())

--- a/src/main/java/com/likelion/realtalk/global/security/jwt/JwtTokenFilter.java
+++ b/src/main/java/com/likelion/realtalk/global/security/jwt/JwtTokenFilter.java
@@ -71,7 +71,7 @@ public class JwtTokenFilter extends OncePerRequestFilter {
             || path.startsWith("/css/")
             || path.startsWith("/js/")
             || path.startsWith("/images/")
-            || path.equals("/actuator/health")
+            || path.startsWith("/actuator/")
 
             // 3. Swagger, API 문서 리소스
             || path.startsWith("/swagger-ui/")


### PR DESCRIPTION
## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- fix/#98

📄  **작업한 내용**
1.	후보 방 조회
- debateRoomRepository.findByCategoryAndStatus(categoryId)
- 해당 카테고리에서 waiting/started 상태의 토론방 목록 불러옴.
- 없으면 NoSuchElementException 발생.
2.	입장 가능 방 필터링 & 선택
- Redis에서 현재 청중 수(currentAudience) 확인.
- 청중석이 꽉 찬 방은 제외.
- 기준:
	1.	청중 수가 더 많은 방
	2.	청중 수가 같으면 → 스피커 수가 더 적은 방
	3.	그래도 같으면 → roomId가 더 작은 방
	•	조건 만족 시 후보 갱신.
3.	최종 방 선택 후 매핑
- PK(roomId)를 UUID로 변환 (roomIdMappingService).
- 로그에 선택 이유/결과 기록.
4.	현재 인원/경과 시간 계산
- Redis 캐시값을 그대로 사용.
- status == waiting이면 elapsedSeconds=0,
started면 startedAt 기준으로 현재 시각까지의 초 계산.
5.	응답 객체 빌드
- DebateRoomResponse 생성: UUID, 제목, 상태, 카테고리 정보, 사이드명, 최대 인원, 현재 인원, 생성자, 경과 시간 등 세팅.

## 🚨 참고 사항
- 서버에서 테스트 필요!

## 💻 관련 이슈
- Resolved: #98

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
- 예: 이 부분의 로직이 적절한지 확인 부탁드립니다.