### PR TITLE
feat(api): 사이드(A/B) 변경 API 추가 및 프론트 연동

### DIFF
--- a/src/main/java/com/likelion/realtalk/domain/debate/api/DebateController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/DebateController.java
@@ -186,6 +186,7 @@ public class DebateController {
         acc.put("role", req.getRole());
         acc.put("side", req.getSide());
         acc.put("nonce", req.getNonce()); // ★ 추가
+        acc.put("subjectId", subjectId);
         if (userIdOrNull != null) acc.put("userId", userIdOrNull);
 
         messagingTemplate.convertAndSend("/sub/debate-room/" + roomUuid, acc);

--- a/src/main/java/com/likelion/realtalk/domain/debate/api/SideController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/SideController.java
@@ -1,0 +1,33 @@
+
+package com.likelion.realtalk.domain.debate.api;
+
+import com.likelion.realtalk.domain.debate.dto.ChangeSideRequest;
+import com.likelion.realtalk.domain.debate.service.SideChangeService;
+import com.likelion.realtalk.domain.debate.service.RoomIdMappingService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/debate-rooms")
+@RequiredArgsConstructor
+public class SideController {
+
+  private final SideChangeService sideChangeService;
+  private final RoomIdMappingService mapping;
+
+  /** 사이드 변경 (A/B) */
+  @PostMapping("/{roomId}/side")
+  public ResponseEntity<?> changeSide(
+      @PathVariable UUID roomId,
+      @RequestBody ChangeSideRequest req
+  ) {
+    // PathVariable과 Body(roomId)가 다를 수 있으니 Path 기준으로 통일
+    Long pk = mapping.toPk(roomId);
+    sideChangeService.changeSideAndBroadcast(pk, req.getSubjectId(), req.getSide());
+    return ResponseEntity.ok().body(
+        java.util.Map.of("ok", true, "side", req.getSide())
+    );
+  }
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/dto/ChangeSideRequest.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/dto/ChangeSideRequest.java
@@ -1,0 +1,11 @@
+package com.likelion.realtalk.domain.debate.dto;
+
+import java.util.UUID;
+import lombok.Data;
+
+@Data
+public class ChangeSideRequest {
+  private UUID roomId;     // 방 UUID
+  private String subjectId; // 유저 식별자(게스트: guest:xxxx 형태 등)
+  private String side;     // "A" or "B"
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/service/SideChangeService.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/service/SideChangeService.java
@@ -1,0 +1,89 @@
+package com.likelion.realtalk.domain.debate.service;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Collection;
+
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.likelion.realtalk.domain.debate.dto.RoomUserInfo;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SideChangeService {
+
+  private final StringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
+
+  // 이미 사용 중인 브로드캐스트/참가자 보관체계
+  private final ParticipantService participantService; // roomParticipants 메모리 맵 접근용
+  private final SideStatsService sideStatsService;     // 게이지 브로드캐스트
+  // private final DebateRoomBroadcaster broadcaster;     // 내부적으로 broadcastParticipantsSpeaker(pk) 제공한다고 가정
+  // 위 broadcaster가 없다면 participantService.broadcastParticipantsSpeaker(pk) 직접 호출하셔도 됩니다.
+
+  private String waitingKey(Long pk) {
+    return "debateRoom:" + pk + ":waitingUsers"; // 예: debateRoom:2:waitingUsers
+  }
+
+  /**
+   * subjectId 사용자의 side를 "A"/"B"로 변경하고, 참가자/통계 브로드캐스트 수행
+   */
+  public void changeSideAndBroadcast(Long pk, String subjectId, String newSide) {
+    String side = normalizeSide(newSide); // "A"/"B"만 허용
+    updateRedisWaitingUsers(pk, subjectId, side);   // Redis JSON 업데이트
+    updateInMemoryParticipants(pk, subjectId, side); // 서버 메모리 객체 동기화(있다면)
+
+    // 실시간 반영
+    participantService.broadcastParticipantsSpeaker(pk); // 기존에 쓰시던 참가자 브로드캐스트
+    participantService.broadcastAllRooms(); // 기존에 쓰시던 참가자 브로드캐스트
+    sideStatsService.broadcast(pk);                      // 새로 만든 A/B 통계 브로드캐스트
+  }
+
+  private String normalizeSide(String s) {
+    String v = (s == null) ? "" : s.trim().toUpperCase();
+    if (!Objects.equals(v, "A") && !Objects.equals(v, "B")) {
+      throw new IllegalArgumentException("side must be 'A' or 'B'");
+    }
+    return v;
+  }
+
+  /** Redis 해시(debateRoom:{pk}:waitingUsers)에서 subjectId 매칭 항목들의 side를 일괄 변경 */
+  private void updateRedisWaitingUsers(Long pk, String subjectId, String side) {
+    HashOperations<String, String, String> ops = redisTemplate.opsForHash();
+    String key = waitingKey(pk);
+    Map<String, String> all = ops.entries(key);
+    if (all == null || all.isEmpty()) return;
+
+    for (Map.Entry<String, String> e : all.entrySet()) {
+      try {
+        JsonNode n = objectMapper.readTree(e.getValue());
+        String sub = n.path("subjectId").asText(null);
+        if (subjectId != null && subjectId.equals(sub)) {
+          if (n instanceof ObjectNode on) {
+            on.put("side", side);
+            ops.put(key, e.getKey(), objectMapper.writeValueAsString(on));
+          }
+        }
+      } catch (Exception ignore) {}
+    }
+  }
+
+  /** 서버 메모리 roomParticipants에도 반영(가지고 계신 구조에 맞게 보정) */
+    private void updateInMemoryParticipants(Long pk, String subjectId, String side) {
+    Collection<RoomUserInfo> users = participantService.getDetailedUsersInRoom(pk);
+    if (users == null || users.isEmpty()) return;
+
+    for (RoomUserInfo u : users) {
+        if (u != null && subjectId.equals(u.getSubjectId())) {
+        u.setSide(side); // 컬렉션이 map.values() 뷰라 바로 반영됨
+        }
+    }
+    }
+}

--- a/src/main/resources/static/debateroom.html
+++ b/src/main/resources/static/debateroom.html
@@ -55,6 +55,11 @@
             <option value="B">B</option>
         </select><br>
         <button onclick="joinRoomFromForm()">Join Room</button>
+        <!-- ⬇️ 사이드 변경 버튼 2개 추가 -->
+        <div style="margin-top:8px;">
+        <button type="button" onclick="changeSideUI('A')">↔️ Change to A</button>
+        <button type="button" onclick="changeSideUI('B')" style="margin-left:6px;">↔️ Change to B</button>
+        </div>
     </div>
 
     <!-- Debate Room List -->
@@ -91,7 +96,7 @@
     let connectInFlight = false;
 
     // [추가] 내 정보 & 락 & (선택) 요청 식별용 nonce
-    const currentUser = { id: null, name: null, role: null, side: null };
+    const currentUser = { id: null, name: null, role: null, side: null, subjectId: null };
     let selfInfoLocked = false;   // 내 "You are:" UI는 한 번만 세팅
     let myJoinNonce = null;       // 서버가 echo 해주면 정확 매칭용(없어도 동작)
 
@@ -297,6 +302,8 @@
                         currentUser.name = userName ?? null;
                         currentUser.role = joinedRole ?? null;
                         currentUser.side = joinedSide ?? null;
+                        // ⬇️ 서버가 보내주면 subjectId 저장 (없으면 그대로 null)
+                        currentUser.subjectId = payload.subjectId ?? currentUser.subjectId ?? null;
 
                         document.getElementById('room-info').textContent = `RoomId: ${roomId}`;
                         document.getElementById('user-info').textContent =
@@ -458,6 +465,46 @@
         currentUser.role = null;
         currentUser.side = null;
         });
+    }
+
+    // 버튼에서 호출: 'A' 또는 'B'
+    async function changeSideUI(nextSide) {
+        if (!currentRoomId) {
+            alert('먼저 방에 입장하세요.');
+            return;
+        }
+        try {
+            console.log("currentRoomId", currentRoomId);
+            console.log("currentUser.subjectId", currentUser.subjectId);
+            console.log("nextSide",nextSide);
+            await setSide(currentRoomId, currentUser.subjectId, nextSide);
+            // 서버가 브로드캐스트하면 구독으로 UI가 갱신됩니다.
+        } catch (e) {
+            alert('사이드 변경 실패: ' + (e?.message || e));
+        }
+    }
+
+    // REST 호출: PUT /api/rooms/{roomId}/side
+    async function setSide(roomUuid, subjectId, side) {
+        if (!side || !['A','B'].includes(side)) {
+            throw new Error('side must be A or B');
+        }
+
+        // 백엔드가 토큰/세션으로 사용자 식별한다면 subjectId 없이 보내도 됩니다.
+        // const body = { roomId: roomUuid, side };
+
+        const body = { roomId: roomUuid, subjectId, side };
+
+        const res = await fetch(`/api/debate-rooms/${roomUuid}/side`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body)
+        });
+        if (!res.ok) {
+            const text = await res.text();
+            throw new Error(text || `HTTP ${res.status}`);
+        }
+        return res.json().catch(() => ({}));
     }
 
     window.onload = loadRooms;


### PR DESCRIPTION
- POST /api/debate-rooms/{roomId}/side 엔드포인트 구현
  - 요청: { subjectId, side } (+ roomId는 PathVar 기준)
  - 응답: { ok: true, side }
  - 내부에서 Redis/메모리 참가자 정보 업데이트 후 실시간 브로드캐스트
- 프론트 changeSideUI, setSide 함수 추가
  - currentRoomId, currentUser.subjectId, nextSide 기반으로 REST 호출
  - 성공 시 서버 브로드캐스트 구독을 통해 UI 자동 갱신
- 사이드 변경 버튼(UI) 추가 (↔️ Change to A / B)

## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- feature/#99

📄  **작업한 내용**

## 🚨 참고 사항

## 💻 관련 이슈
- Resolved: #99

## 💬 리뷰 요구사항 (선택)