### PR TITLE
feat(debate): 토론 주제 CRUD 기능 및 관리 페이지 추가

### DIFF
--- a/src/main/java/com/likelion/realtalk/domain/debate/api/DebateTopicController.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/api/DebateTopicController.java
@@ -1,0 +1,45 @@
+package com.likelion.realtalk.domain.debate.api;
+
+import com.likelion.realtalk.domain.debate.dto.DebateTopicDto.CreateDebateTopicRequest;
+import com.likelion.realtalk.domain.debate.dto.DebateTopicDto.DebateTopicResponse;
+import com.likelion.realtalk.domain.debate.entity.DebateTopic;
+import com.likelion.realtalk.domain.debate.service.DebateTopicService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/debate-topics")
+@RequiredArgsConstructor
+public class DebateTopicController {
+
+    private final DebateTopicService service;
+
+    // 1) 제목 추가
+    @PostMapping
+    public ResponseEntity<DebateTopicResponse> create(@Valid @RequestBody CreateDebateTopicRequest req) {
+        DebateTopic saved = service.create(req);
+        return ResponseEntity
+                .created(URI.create("/api/debate-topics/" + saved.getId()))
+                .body(DebateTopicResponse.of(saved));
+    }
+
+    // 2) 전체 조회
+    @GetMapping
+    public List<DebateTopicResponse> list() {
+        return service.findAll().stream()
+                .map(DebateTopicResponse::of)
+                .toList();
+    }
+
+    // 3) 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        service.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/dto/DebateTopicDto.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/dto/DebateTopicDto.java
@@ -1,0 +1,22 @@
+package com.likelion.realtalk.domain.debate.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public class DebateTopicDto {
+
+    // 생성 요청 DTO
+    public record CreateDebateTopicRequest(
+            @NotBlank @Size(max = 200) String title
+    ) {}
+
+    // 응답 DTO
+    public record DebateTopicResponse(
+            Long id,
+            String title
+    ) {
+        public static DebateTopicResponse of(com.likelion.realtalk.domain.debate.entity.DebateTopic e) {
+            return new DebateTopicResponse(e.getId(), e.getTitle());
+        }
+    }
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/entity/DebateTopic.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/entity/DebateTopic.java
@@ -1,0 +1,21 @@
+package com.likelion.realtalk.domain.debate.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "debate_topic")
+public class DebateTopic {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200, unique = true)
+    private String title;
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/repository/DebateTopicRepository.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/repository/DebateTopicRepository.java
@@ -1,0 +1,8 @@
+package com.likelion.realtalk.domain.debate.repository;
+
+import com.likelion.realtalk.domain.debate.entity.DebateTopic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DebateTopicRepository extends JpaRepository<DebateTopic, Long> {
+    boolean existsByTitle(String title);
+}

--- a/src/main/java/com/likelion/realtalk/domain/debate/service/DebateTopicService.java
+++ b/src/main/java/com/likelion/realtalk/domain/debate/service/DebateTopicService.java
@@ -1,0 +1,44 @@
+package com.likelion.realtalk.domain.debate.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.domain.Sort;
+
+import com.likelion.realtalk.domain.debate.dto.DebateTopicDto.CreateDebateTopicRequest;
+import com.likelion.realtalk.domain.debate.entity.DebateTopic;
+import com.likelion.realtalk.domain.debate.repository.DebateTopicRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DebateTopicService {
+
+    private final DebateTopicRepository repository;
+
+    @Transactional
+    public DebateTopic create(CreateDebateTopicRequest req) {
+        if (repository.existsByTitle(req.title())) {
+            throw new IllegalArgumentException("이미 존재하는 토론 주제입니다: " + req.title());
+        }
+        DebateTopic topic = DebateTopic.builder()
+                .title(req.title())
+                .build();
+        return repository.save(topic);
+    }
+
+public List<DebateTopic> findAll() {
+    return repository.findAll(Sort.by(Sort.Direction.ASC, "id")); // id 오름차순
+}
+
+    @Transactional
+    public void delete(Long id) {
+        if (!repository.existsById(id)) {
+            throw new IllegalArgumentException("존재하지 않는 토론 주제입니다: " + id);
+        }
+        repository.deleteById(id);
+    }
+}

--- a/src/main/resources/static/debate-topics.html
+++ b/src/main/resources/static/debate-topics.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <title>토론 주제 관리</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; margin: 24px; }
+    h1 { margin-bottom: 12px; }
+    form { display: flex; gap: 8px; margin-bottom: 16px; }
+    input[type="text"] { flex: 1; padding: 8px; font-size: 14px; }
+    button { padding: 8px 12px; cursor: pointer; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ddd; padding: 8px; }
+    th { background: #f7f7f7; text-align: left; }
+    .row-actions { display: flex; gap: 8px; }
+    #toast { position: fixed; top: 16px; right: 16px; background:#333; color:#fff; padding:10px 14px; border-radius:6px; opacity:0; transition: opacity .2s ease; }
+    #toast.show { opacity: 1; }
+  </style>
+</head>
+<body>
+  <h1>토론 주제 관리</h1>
+
+  <form id="create-form">
+    <input id="title-input" type="text" placeholder="토론 주제 제목을 입력하세요" maxlength="200" required />
+    <button type="submit">추가</button>
+    <button type="button" id="refresh-btn">새로고침</button>
+  </form>
+
+  <table id="topic-table">
+    <thead>
+      <tr>
+        <th style="width: 120px;">ID</th>
+        <th>제목</th>
+        <th style="width: 160px;">액션</th>
+      </tr>
+    </thead>
+    <tbody>
+      <!-- rows -->
+    </tbody>
+  </table>
+
+  <div id="toast"></div>
+
+  <script>
+    const API_BASE = '/api/debate-topics';
+
+    const $ = (sel) => document.querySelector(sel);
+    const $$ = (sel) => Array.from(document.querySelectorAll(sel));
+
+    const toast = (msg, ms = 1600) => {
+      const t = $('#toast');
+      t.textContent = msg;
+      t.classList.add('show');
+      setTimeout(() => t.classList.remove('show'), ms);
+    };
+
+    async function listTopics() {
+      const res = await fetch(API_BASE, { method: 'GET' });
+      if (!res.ok) {
+        toast('목록 조회 실패');
+        return;
+      }
+      const data = await res.json();
+      renderRows(data);
+    }
+
+    function renderRows(rows) {
+      const tbody = $('#topic-table tbody');
+      tbody.innerHTML = '';
+      if (!rows || rows.length === 0) {
+        const tr = document.createElement('tr');
+        const td = document.createElement('td');
+        td.colSpan = 3;
+        td.textContent = '주제가 없습니다. 추가해 보세요.';
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+        return;
+      }
+
+      for (const r of rows) {
+        const tr = document.createElement('tr');
+
+        const tdId = document.createElement('td');
+        tdId.textContent = r.id;
+
+        const tdTitle = document.createElement('td');
+        tdTitle.textContent = r.title;
+
+        const tdActions = document.createElement('td');
+        tdActions.className = 'row-actions';
+
+        const delBtn = document.createElement('button');
+        delBtn.textContent = '삭제';
+        delBtn.onclick = async () => {
+          if (!confirm(`삭제하시겠습니까?\n[${r.id}] ${r.title}`)) return;
+          const res = await fetch(`${API_BASE}/${r.id}`, { method: 'DELETE' });
+          if (res.status === 204) {
+            toast('삭제 완료');
+            await listTopics();
+          } else {
+            const text = await res.text();
+            toast('삭제 실패: ' + (text || res.status));
+          }
+        };
+
+        tdActions.appendChild(delBtn);
+
+        tr.appendChild(tdId);
+        tr.appendChild(tdTitle);
+        tr.appendChild(tdActions);
+
+        tbody.appendChild(tr);
+      }
+    }
+
+    async function createTopic(title) {
+      const payload = { title };
+      const res = await fetch(API_BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (res.ok) {
+        toast('추가 완료');
+        $('#title-input').value = '';
+        await listTopics();
+      } else {
+        const text = await res.text();
+        toast('추가 실패: ' + (text || res.status));
+      }
+    }
+
+    // Handlers
+    $('#create-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const title = $('#title-input').value.trim();
+      if (!title) return;
+      await createTopic(title);
+    });
+
+    $('#refresh-btn').addEventListener('click', listTopics);
+
+    // init
+    listTopics();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
- DebateTopic 엔티티(id, title) 생성
- DebateTopicDto 내부 record(CreateDebateTopicRequest, DebateTopicResponse) 정의
- Service/Controller에 주제 추가, 전체 조회, 삭제 API 구현
- 조회 시 id ASC 정렬 적용
- static/debate-topics.html 추가 (브라우저에서 주제 추가/조회/삭제 가능)

## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- feature/#이슈번호

📄  **작업한 내용**
<!-- 작업에 대한 간략한 설명 -->

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 💻 관련 이슈
- Resolved: #이슈번호

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
- 예: 이 부분의 로직이 적절한지 확인 부탁드립니다.